### PR TITLE
Separate compatibility info from prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,15 @@ Enable AI agents to set up Antithesis and bootstrap your first Antithesis test. 
 > [!NOTE]
 > These skills are under active development. LLMs are inherently non-deterministic, so they may not work perfectly with your AI. Please do file issues and submit PRs as you come across ways to improve them.
 
+## Compatibility
+
+**Platform**: macOS or Linux.
+
+**AI agent**: Tested with [Claude Code](https://docs.anthropic.com/en/docs/claude-code) and [OpenAI Codex](https://openai.com/index/openai-codex/). Other agents that support skills may also work.
+
 ## Prerequisites
 
-These skills work with [Claude Code](https://docs.anthropic.com/en/docs/claude-code) or [OpenAI Codex](https://openai.com/index/openai-codex/) on macOS or Linux. Install at least one of these before proceeding.
+Install an AI agent that supports skills (see above).
 
 The installer runs via `npx`, which ships with [Node.js](https://nodejs.org/). Install Node.js if you don't already have it.
 


### PR DESCRIPTION
The old Prerequisites section conflated what we've tested with (agents, platforms) and what needs to be installed. Split into "Compatibility" for what's supported and "Prerequisites" for installation requirements. Makes the hard platform constraint (macOS/Linux only) and the softer agent compatibility ("tested with X, others may work") clearer.