### PR TITLE
Fix misleading npx prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Enable AI agents to set up Antithesis and bootstrap your first Antithesis test. 
 
 Install an AI agent that supports skills (see above).
 
-The installer runs via `npx`, which ships with [Node.js](https://nodejs.org/). Install Node.js if you don't already have it.
+The installer runs via `npx`, which ships with [npm](https://www.npmjs.com/). Install npm if you don't already have it.
 
 [Snouty CLI](https://github.com/antithesishq/snouty) is used by the documentation skill to search and retrieve docs. Install it before proceeding. Antithesis also depends on [Docker](https://github.com/docker) and [Docker Compose](https://docs.docker.com/compose/install/), please install those too!. 
 


### PR DESCRIPTION
npx ships with npm, not Node.js. On Debian, the nodejs package doesn't include npm, so users following the old instructions wouldn't get npx. Updated the prerequisite to point to npm instead.

Closes #26