### PR TITLE
Remove outdated agent selection step from install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ The installer presents an interactive menu. Choose the following options:
    - `antithesis-workload`
 2. **Install scope** — choose **global**, not project.
 3. **Install method** — choose **symlink**.
-4. **Agents** — only select agents you have installed (Claude Code, Codex, or both). Do not install the `find-skills` skill.
 
 Restart any open agent sessions after installing so the new skills are discovered.
 


### PR DESCRIPTION
The installer auto-detects installed agents rather than prompting the user to select them. Removes the step that told users to manually select agents.

Closes #27