### PR TITLE
Enforce linux/amd64 platform in docker-compose examples and templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ Install an AI agent that supports skills (see above).
 
 The installer runs via `npx`, which ships with [npm](https://www.npmjs.com/). Install npm if you don't already have it.
 
-[Snouty CLI](https://github.com/antithesishq/snouty) is used by the documentation skill to search and retrieve docs. Install it before proceeding. You will also need either [Docker](https://github.com/docker) and [Docker Compose](https://docs.docker.com/compose/install/), or [Podman](https://podman.io/), please install those too!. 
+[Snouty CLI](https://github.com/antithesishq/snouty) is used by the documentation skill to search and retrieve docs. Install it before proceeding. You will also need either [Docker](https://github.com/docker) and [Docker Compose](https://docs.docker.com/compose/install/), or [Podman](https://podman.io/), please install those too!
+
+If building on macOS ARM (Apple Silicon), ensure your container runtime can build `linux/amd64` images. Antithesis runs on x86-64, so all images must target that architecture.
 
 ## Install
 

--- a/antithesis-setup/assets/antithesis/config/docker-compose.yaml
+++ b/antithesis-setup/assets/antithesis/config/docker-compose.yaml
@@ -3,12 +3,14 @@
 #
 # Local images use `build:` so `compose build` can build them before `snouty run`.
 # Public images (e.g. postgres, redis) use `image:` directly.
+# Every service MUST include `platform: linux/amd64` — Antithesis runs on x86-64.
 #
 # Example:
 #   services:
 #     myapp:
 #       container_name: myapp
 #       hostname: myapp
+#       platform: linux/amd64
 #       build:
 #         context: ../..           # repo root (relative to this file)
 #         dockerfile: Dockerfile
@@ -17,9 +19,11 @@
 #     postgres:
 #       container_name: postgres
 #       hostname: postgres
+#       platform: linux/amd64
 #       image: docker.io/library/postgres:17.2
 
 services:
   noop:
+    platform: linux/amd64
     image: busybox:1.36
     command: ["sh", "-c", "tail -f /dev/null"]

--- a/antithesis-setup/references/docker-compose.md
+++ b/antithesis-setup/references/docker-compose.md
@@ -13,16 +13,20 @@ Services use one of two patterns:
 - **Local images** use `build:` with a context path and `image:` with `name:tag`. Build these before invoking `snouty run`.
 - **Public images** use `image:` directly (e.g. `docker.io/library/postgres:17.2`).
 
+Every service must include `platform: linux/amd64` because Antithesis runs on x86-64. This applies to both local and public images — without it, builds and pulls on ARM hosts (e.g. macOS Apple Silicon) will produce the wrong architecture.
+
 Example:
 ```yaml
 services:
   myapp:
+    platform: linux/amd64
     build:
       context: ../..
       dockerfile: Dockerfile
     image: myapp:latest
 
   postgres:
+    platform: linux/amd64
     image: docker.io/library/postgres:17.2
 ```
 

--- a/antithesis-setup/references/docker-images.md
+++ b/antithesis-setup/references/docker-images.md
@@ -21,11 +21,12 @@ Apply the `references/instrumentation.md` decisions while you adapt images:
 - Prefer symlinks into `/symbols/` when the original debug files already exist elsewhere in the image and the docs permit it.
 - Keep instrumentation-only toolchain changes out of unrelated production image paths when practical by using Antithesis-specific build stages.
 
-Reference each local image in `docker-compose.yaml` with both `build:` (for local `compose build`) and `image:` (for the registry tag):
+Reference each local image in `docker-compose.yaml` with both `build:` (for local `compose build`) and `image:` (for the registry tag). Every service must include `platform: linux/amd64` because Antithesis runs on x86-64. Without this, builds on ARM hosts (e.g. macOS Apple Silicon) will produce images with the wrong architecture.
 
 ```yaml
 services:
   myapp:
+    platform: linux/amd64
     build:
       context: ../..
       dockerfile: antithesis/Dockerfile
@@ -39,5 +40,5 @@ If the deployment includes a client or workload image, make sure it can later re
 
 ## Requirements
 
-- All images must target Linux x86-64.
+- All images must target Linux x86-64. Set `platform: linux/amd64` on every service in docker-compose.yaml — both `build:` services and `image:`-only services (public images like postgres will also pull the wrong architecture on ARM hosts without it).
 - Follow the Docker best practices guide: `https://antithesis.com/docs/best_practices/docker_best_practices.md`

--- a/antithesis-setup/references/instrumentation.md
+++ b/antithesis-setup/references/instrumentation.md
@@ -89,6 +89,7 @@ If the deployment is polyglot, read every relevant file before you touch Dockerf
 
 When adapting Dockerfiles for Antithesis:
 
+- Ensure every service in docker-compose.yaml includes `platform: linux/amd64`. Antithesis runs on x86-64; images built for other architectures will not work.
 - Add any instrumentation-only build tools, compile flags, or helper binaries in Antithesis-specific stages when practical.
 - Ensure the runtime image includes the Antithesis SDK dependencies needed by the code path that emits the bootstrap property.
 - Add `/opt/antithesis/catalog/` for languages that rely on catalog discovery.

--- a/antithesis-setup/references/submit-and-test.md
+++ b/antithesis-setup/references/submit-and-test.md
@@ -9,13 +9,14 @@ Before submitting to Antithesis, test locally:
 - Use `podman compose` if available; fall back to `docker compose`.
 - Verify that the compose file builds using either `podman compose -f /path/to/config/docker-compose.yaml build` or `docker compose -f /path/to/config/docker-compose.yaml build`.
 - Run any language-specific local instrumentation checks described in `references/instrumentation.md`, such as `nm` or `ldd`, before relying on the first Antithesis run to catch packaging mistakes.
+- Verify that all built images target `amd64`. For each locally built image, run `podman image inspect <image> --format '{{.Architecture}}'` (or `docker image inspect <image> --format '{{.Architecture}}'`) and confirm the output is `amd64`. If any image reports `arm64`, the `platform: linux/amd64` directive is missing or ineffective — fix the compose file before proceeding.
 - Use `snouty validate /path/to/config-dir` to ensure that the compose setup can reach setup complete and any configured test-templates work.
 - This step is not complete until you can test the deployment locally and prove the harness is ready for workload execution.
 
 ## Preparing Submission
 
 - Review all files in the antithesis directory.
-- Build images first: `podman compose -f antithesis/config/docker-compose.yaml build` (or `docker compose` if podman is unavailable).
+- Build images first: `podman compose -f antithesis/config/docker-compose.yaml build` (or `docker compose` if podman is unavailable). The `platform: linux/amd64` directive in each service ensures builds target x86-64 even on ARM hosts.
 - Snouty handles the rest: it pushes tagged images, consumes the config directory, interpolates env vars, and launches the run.
 
 ## Environment Setup


### PR DESCRIPTION
On macOS ARM (Apple Silicon), container builds default to `linux/arm64`, but Antithesis runs on x86-64. The skills mentioned this requirement once in passing (`docker-images.md`: "All images must target Linux x86-64") but never enforced it — agents following the examples would produce images with the wrong architecture.

- Add `platform: linux/amd64` to every docker-compose YAML example across `docker-images.md`, `docker-compose.md`, and the starter template
- Add an architecture verification step to the local testing checklist in `submit-and-test.md`
- Add a one-liner to `instrumentation.md`'s image construction guidance
- Note the cross-architecture build prerequisite in the README

Closes #25