### PR TITLE
Add self-review step to all skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Enable AI agents to set up Antithesis and bootstrap your first Antithesis test. 
 
 **Platform**: macOS or Linux.
 
-**AI agent**: Tested with [Claude Code](https://docs.anthropic.com/en/docs/claude-code) and [OpenAI Codex](https://openai.com/index/openai-codex/). Other agents that support skills may also work.
+**AI agent**: Tested with [Claude Code](https://docs.anthropic.com/en/docs/claude-code) and [OpenAI Codex](https://openai.com/index/openai-codex/). These skills work best with agents that can spawn sub-agents for self-review. Other agents that support skills may also work.
 
 ## Prerequisites
 

--- a/antithesis-documentation/SKILL.md
+++ b/antithesis-documentation/SKILL.md
@@ -73,3 +73,14 @@ If you want to link a user directly to a section, use a fragment with the slugif
 - Clear, grounded answers about Antithesis behavior, SDKs, setup, and best practices.
 - Relevant links to the documentation pages you used.
 - If the `snouty` command is missing ask the user if they want to install it, telling them that it is a CLI for working with the Antithesis API and docs.
+
+## Self-Review
+
+Before declaring this skill complete, review your work against the criteria below. This skill's output is conversational (answers grounded in documentation), so the review should happen in your current context. Re-read the guidance in this file, then systematically check each item below against the answers you produced.
+
+Review criteria:
+
+- Every factual claim in your answer is grounded in a specific documentation page you retrieved via `snouty docs` or direct markdown fetch
+- Documentation page links are included so the user can verify your sources
+- You have not mixed up concepts from different pages or added details not present in the source material
+- If the docs were ambiguous or silent on a point, you said so rather than filling the gap with assumptions

--- a/antithesis-research/SKILL.md
+++ b/antithesis-research/SKILL.md
@@ -107,3 +107,18 @@ Use the `antithesis-documentation` skill to ground Antithesis-specific terminolo
 - `antithesis/scratchbook/deployment-topology.md`
 
 These outputs should be concrete enough for the `antithesis-setup` skill and the `antithesis-workload` skill to use directly.
+
+## Self-Review
+
+Before declaring this skill complete, review your work against the criteria below. If your agent supports spawning sub-agents, create a new agent with fresh context to perform this review — give it the path to this skill file and have it read all output artifacts. A fresh-context reviewer catches blind spots that in-context review misses. If your agent does not support sub-agents, perform the review yourself: re-read the success criteria at the top of this file, then systematically check each item below against your actual output.
+
+Review criteria:
+
+- `antithesis/scratchbook/sut-analysis.md` exists and covers architecture, state management, concurrency model, and failure-prone areas
+- `antithesis/scratchbook/property-catalog.md` exists and lists concrete, testable properties — not vague goals like "test failover"
+- Each property has a priority and a rationale for its chosen Antithesis assertion type (`Always`, `Sometimes`, `Reachable`, etc.)
+- `antithesis/scratchbook/deployment-topology.md` exists and describes a minimal container topology — every container is justified
+- Properties focus on timing-sensitive, concurrency-sensitive, and partial-failure scenarios where Antithesis is strongest
+- Claimed guarantees from docs, comments, or issues are represented as properties
+- Assumptions and open questions are recorded in the scratchbook, not left implicit
+- The outputs are concrete enough for `antithesis-setup` and `antithesis-workload` to use directly — no ambiguous steps or missing details

--- a/antithesis-setup/SKILL.md
+++ b/antithesis-setup/SKILL.md
@@ -68,3 +68,20 @@ This skill is broken out into multiple steps, each in a different reference file
 - Treat local testing as required before the first submission.
 - Use `snouty run` directly to submit runs. Run `compose build` before `snouty run` to ensure images are up to date.
 - Do not add a separate Dockerfile under `antithesis/config/` unless the deployment explicitly requires it.
+
+## Self-Review
+
+Before declaring this skill complete, review your work against the criteria below. If your agent supports spawning sub-agents, create a new agent with fresh context to perform this review — give it the path to this skill file and have it read all output artifacts. A fresh-context reviewer catches blind spots that in-context review misses. If your agent does not support sub-agents, perform the review yourself: re-read the success criteria at the top of this file, then systematically check each item below against your actual output.
+
+Review criteria:
+
+- `antithesis/config/docker-compose.yaml` exists and every service has `build:` (for local images) or `image:` (for public images) configured correctly
+- Every service in docker-compose.yaml includes `platform: linux/amd64`
+- The instrumentation inventory from `references/instrumentation.md` is fully implemented: each service is instrumented, cataloged-only, or explicitly documented as uninstrumented
+- The relevant Antithesis SDK is installed in the SUT dependency graph
+- A bootstrap property exists in a simple, guaranteed-to-run code path (not behind rare behavior)
+- `/opt/antithesis/catalog/` or `/symbols/` is exposed correctly for each service's language
+- The `setup_complete` signal is wired in at least one entrypoint
+- `snouty validate antithesis/config/` succeeds
+- All built images target `amd64` (verified via `podman image inspect` or `docker image inspect`)
+- The harness is ready for the `antithesis-workload` skill — test template directories exist or are wired for later use

--- a/antithesis-triage/SKILL.md
+++ b/antithesis-triage/SKILL.md
@@ -141,3 +141,16 @@ again.
 - **Logs require full auth.** The report page may load with just an `auth` token in the URL, but navigating to log pages requires a fully authenticated session.
 - **Logs use virtual scrolling.** Only ~50-70 rows render at a time. You may need to scroll to find specific entries.
 - **Present results clearly.** When reporting property statuses, use a table or list. When reporting log findings, include the virtual timestamp, source, and log text.
+
+## Self-Review
+
+Before declaring this skill complete, review your work against the criteria below. This skill's output is conversational (summaries, tables, analysis), so the review should happen in your current context. Re-read the guidance in this file, then systematically check each item below against the answers and analysis you produced.
+
+Review criteria:
+
+- Every property status reported (passed, failed, unfound) was extracted from the actual triage report, not inferred or assumed
+- Findings reference specific data from the report — property names, assertion text, log lines, timestamps
+- No selectors or report data were fabricated — all queries used the reference files' prescribed query files
+- Failed properties include actionable context: the assertion text, relevant log lines, and timeline context
+- The summary distinguishes between what the report shows and what you interpret or recommend
+- If comparing runs, differences are grounded in data from both reports, not just one

--- a/antithesis-workload/SKILL.md
+++ b/antithesis-workload/SKILL.md
@@ -98,3 +98,18 @@ Use the `antithesis-documentation` skill to access these pages. Prefer `snouty d
 - Test commands and supporting workload code under `antithesis/test/`
 - Assertions in workload code or carefully chosen SUT locations
 - Updates to `antithesis/scratchbook/property-catalog.md` when the implemented properties change
+
+## Self-Review
+
+Before declaring this skill complete, review your work against the criteria below. If your agent supports spawning sub-agents, create a new agent with fresh context to perform this review — give it the path to this skill file and have it read all output artifacts. A fresh-context reviewer catches blind spots that in-context review misses. If your agent does not support sub-agents, perform the review yourself: re-read the success criteria at the top of this file, then systematically check each item below against your actual output.
+
+Review criteria:
+
+- Every property in the catalog that was in scope has a corresponding SDK assertion in the workload or SUT code
+- Each assertion uses the correct SDK assertion type for its property's semantics (`Always`/`AlwaysOrUnreachable` for safety, `Sometimes` for liveness, `Reachable`/`Unreachable` for code path checks)
+- Test commands exist under `antithesis/test/` and use valid prefixes (`parallel_driver_`, `singleton_driver_`, `serial_driver_`, `first_`, `eventually_`, `finally_`, `anytime_`)
+- Test commands are written in the project's language, not Bash, and reuse the project's clients and libraries where possible
+- Test templates are structured correctly at the path that will map to `/opt/antithesis/test/v1/{name}/` in the container
+- Helper files or directories are prefixed with `helper_` so Test Composer ignores them
+- `antithesis/scratchbook/property-catalog.md` is updated to reflect which properties are now implemented
+- Assertions are in workload code or surgical SUT locations — not scattered across production paths


### PR DESCRIPTION
Each skill now instructs the agent to review its work against skill-specific criteria before declaring "done."

- **Artifact-producing skills** (research, setup, workload) recommend spawning a fresh-context sub-agent for the review, with an in-context fallback for agents that don't support sub-agents
- **Conversational-output skills** (documentation, triage) direct the agent to review in its current context since there are no files for a sub-agent to read
- README updated to note that skills work best with agents that can spawn sub-agents