### PR TITLE
Exclude sites that block CI traffic from link checking

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -3,4 +3,6 @@ no_progress = true
 cache = true
 exclude = [
   '^https://tenant\.antithesis\.com/?$',
+  '^https://openai\.com/',
+  '^https://www\.npmjs\.com/',
 ]


### PR DESCRIPTION
openai.com and npmjs.com return 403 to GitHub Actions runners, causing false positive failures in both the nightly and PR link checks. Added them to the lychee.toml exclude list.