### PR TITLE
Add structured property discovery to research skill

### DIFF
--- a/antithesis-research/SKILL.md
+++ b/antithesis-research/SKILL.md
@@ -61,7 +61,8 @@ Use the `antithesis-documentation` skill to ground Antithesis-specific terminolo
 | ----------------------------------- | --------------------------------------------------- |
 | `references/scratchbook-setup.md`      | Always — read first to initialize the workspace     |
 | `references/sut-analysis.md`        | Analyzing the codebase and understanding components |
-| `references/property-catalog.md`    | Identifying and documenting testable properties     |
+| `references/property-discovery.md`  | Discovering properties through structured attention focuses |
+| `references/property-catalog.md`    | Format and methodology for documenting properties   |
 | `references/deployment-topology.md` | Designing the container topology for Antithesis     |
 
 ## Recommended Workflows
@@ -70,22 +71,24 @@ Use the `antithesis-documentation` skill to ground Antithesis-specific terminolo
 
 1. Read `references/scratchbook-setup.md`
 2. Read `references/sut-analysis.md`
-3. Read `references/property-catalog.md`
-4. Read `references/deployment-topology.md`
-5. Write or update all findings in the scratchbook under `antithesis/scratchbook/`
+3. Read `references/property-discovery.md` and `references/property-catalog.md`
+4. Discover properties using the ensemble or single-agent workflow from `references/property-discovery.md`
+5. Read `references/deployment-topology.md`
+6. Write or update all findings in the scratchbook under `antithesis/scratchbook/`
 
 ### Targeted property research
 
 1. Read `references/sut-analysis.md` if the system model is missing or stale
-2. Read `references/property-catalog.md`
-3. Turn claimed guarantees, incidents, and bug reports into explicit properties, and choose the Antithesis assertion type that matches each one
-4. Update `antithesis/scratchbook/property-catalog.md` and record assumptions or open questions
+2. Read `references/property-discovery.md` and `references/property-catalog.md`
+3. Discover properties using the ensemble or single-agent workflow from `references/property-discovery.md`
+4. Turn claimed guarantees, incidents, and bug reports into explicit properties, and choose the Antithesis assertion type that matches each one
+5. Update `antithesis/scratchbook/property-catalog.md` and record assumptions or open questions
 
 ### Property expansion (after triage)
 
-1. Read `references/property-catalog.md`
+1. Read `references/property-discovery.md` and `references/property-catalog.md`
 2. Review triage findings from the `antithesis-triage` skill
-3. Add new properties inspired by discovered behaviors
+3. Use the attention focuses from `references/property-discovery.md` to look for new properties inspired by triage findings
 4. Update the relevant files in the scratchbook
 
 ## General Guidance

--- a/antithesis-research/references/property-discovery.md
+++ b/antithesis-research/references/property-discovery.md
@@ -1,0 +1,144 @@
+# Property Discovery
+
+## Goal
+
+Systematically discover testable properties by examining the system from multiple
+independent perspectives. Each perspective (attention focus) looks at the same
+codebase but prioritizes different failure modes, producing properties that a
+single unstructured pass would miss.
+
+This process runs after the SUT analysis is complete and produces candidate
+properties in the standard catalog format defined in `references/property-catalog.md`.
+
+## Prerequisites
+
+- `antithesis/scratchbook/sut-analysis.md` exists and is current
+
+## Attention Focuses
+
+Each focus defines a lens for examining the system. Every focus should produce
+properties in the standard catalog format.
+
+### 1. Data Integrity
+
+Consistency guarantees, invariants on stored state, corruption paths. Look for:
+write ordering assumptions, transaction boundaries, constraint enforcement, data
+loss scenarios under concurrent access.
+
+### 2. Concurrency
+
+Races, atomicity, ordering dependencies, shared mutable state. Look for: lock
+ordering, TOCTOU patterns, concurrent container access, thread-safety assumptions
+in documentation vs. implementation.
+
+### 3. Failure Recovery
+
+Crash recovery, restart correctness, partial failure handling, retry semantics.
+Look for: incomplete operations that survive restarts, recovery procedures that
+assume clean state, retry storms, idempotency gaps in recovery paths.
+
+### 4. Protocol Contracts
+
+API guarantees, message ordering, schema validation, backward compatibility. Look
+for: documented API guarantees that aren't enforced, ordering assumptions between
+services, response codes that mask errors.
+
+### 5. Resource Boundaries
+
+Exhaustion, leaks, backpressure, capacity limits, queue depths. Look for:
+unbounded queues, missing backpressure, file descriptor leaks, memory growth under
+sustained load, connection pool exhaustion.
+
+### 6. Security Boundaries
+
+Authentication/authorization invariants, privilege escalation paths, input
+validation. Look for: operations that bypass auth checks, role escalation through
+sequences of valid operations, injection points.
+
+### 7. Distributed Coordination
+
+Consensus, leader election, split-brain, network partition behavior, replication.
+Look for: split-brain recovery, replication lag visibility, quorum loss handling,
+stale leader commands. May yield no properties for single-process systems.
+
+### 8. Lifecycle Transitions
+
+Startup, shutdown, upgrade, migration, initialization ordering. Look for: requests
+during startup before subsystems are ready, graceful shutdown that drops in-flight
+work, migration steps that assume no concurrent traffic.
+
+### 9. Idempotency and Replay
+
+Duplicate handling, at-least-once delivery, reprocessing safety. Look for: side
+effects on retry, message deduplication gaps, replay of already-applied operations.
+
+### 10. Version Compatibility
+
+Behavioral differences across client/server version combinations, backward/forward
+compatibility guarantees, deprecation boundary correctness. Look for: changed
+serialization formats, removed/renamed fields, different default values across
+versions, protocol negotiation failures.
+
+## Ensemble Mode
+
+If your environment supports spawning sub-agents, run property discovery as an
+ensemble — one agent per attention focus, in parallel.
+
+### Agent Instructions
+
+Spawn one agent per focus. Each agent receives:
+
+- The contents of `antithesis/scratchbook/sut-analysis.md`
+- The property catalog format from `references/property-catalog.md`
+- One attention focus (its full description and "look for" guidance from above)
+- These instructions:
+
+> Examine the codebase through the lens of your assigned attention focus. Produce
+> properties in the standard catalog format. For each property, include your
+> confidence (high/medium/low) and what evidence in the codebase supports it. If
+> this focus yields no relevant properties for this system, say so and explain why.
+
+### Agent Output Format
+
+Each agent returns:
+
+- Properties in catalog format (may be empty)
+- A brief note on what areas of the codebase it examined
+- Assumptions made or open questions encountered
+
+### Synthesis
+
+After all agents complete, synthesize into a single property catalog:
+
+- **Deduplicate:** Multiple agents finding the same property is a confidence
+  signal. Merge duplicates, noting which focuses identified them.
+- **Preserve unique finds:** Properties found by only one focus are the primary
+  value of the ensemble — don't drop them without cause.
+- **Resolve conflicts:** When agents disagree on assertion type or priority for
+  the same property, evaluate which reasoning is stronger. Note the disagreement
+  and resolution in the property's rationale.
+- **Renumber and organize:** Assign final IDs and group into categories per the
+  catalog format.
+- **Record provenance:** For each property, note which focus(es) surfaced it.
+
+## Single-Agent Mode
+
+If your environment does not support sub-agents, work through the attention
+focuses as a sequential checklist:
+
+1. Read the SUT analysis.
+2. For each attention focus in order, make an explicit pass through the codebase
+   with that lens. After each pass, add new properties to a running catalog. If a
+   focus yields nothing for this system, note why and move on.
+3. After all 10 passes, review the full catalog for duplicates, gaps, and
+   consistency.
+4. Organize into final form per the catalog format.
+
+Treat each pass as a fresh examination. Resist the pull to skip a focus because
+earlier passes "already covered" that area — the point is to look at the same code
+from different angles.
+
+## Output
+
+The output feeds into `antithesis/scratchbook/property-catalog.md` using the
+format defined in `references/property-catalog.md`.


### PR DESCRIPTION
Adds a new reference file (`references/property-discovery.md`) that structures property discovery around 10 attention focuses: data integrity, concurrency, failure recovery, protocol contracts, resource boundaries, security boundaries, distributed coordination, lifecycle transitions, idempotency/replay, and version compatibility.

Two execution modes:
- **Ensemble mode** — one sub-agent per focus in parallel, then synthesize results into a unified catalog
- **Single-agent mode** — same focuses used as a sequential checklist for environments that don't support sub-agents

Also updates SKILL.md to integrate the discovery process into all three research workflows (full pass, targeted, post-triage expansion).