### PR TITLE
Add per-property evidence files and relationship map to research output

### DIFF
--- a/antithesis-research/SKILL.md
+++ b/antithesis-research/SKILL.md
@@ -23,6 +23,8 @@ Research a target system and produce scratchbook artifacts that unblock the rest
 - `antithesis/scratchbook/sut-analysis.md` captures architecture, state, concurrency, and failure-prone areas
 - `antithesis/scratchbook/property-catalog.md` lists concrete, testable properties with priorities
 - `antithesis/scratchbook/deployment-topology.md` describes the minimal useful container topology
+- `antithesis/scratchbook/properties/{slug}.md` captures per-property evidence trails and context
+- `antithesis/scratchbook/property-relationships.md` maps suspected clusters and connections between properties
 
 ## Prerequisites and Scoping
 
@@ -85,6 +87,8 @@ Use the `antithesis-documentation` skill to ground Antithesis-specific terminolo
 3. Discover properties using the ensemble or single-agent workflow from `references/property-discovery.md`
 4. Turn claimed guarantees, incidents, and bug reports into explicit properties, and choose the Antithesis assertion type that matches each one
 5. Update `antithesis/scratchbook/property-catalog.md` and record assumptions or open questions
+6. Write evidence files for new properties to `antithesis/scratchbook/properties/{slug}.md`
+7. Update `antithesis/scratchbook/property-relationships.md` with any new clusters or connections
 
 ### Property expansion (after triage)
 
@@ -92,6 +96,8 @@ Use the `antithesis-documentation` skill to ground Antithesis-specific terminolo
 2. Review triage findings from the `antithesis-triage` skill
 3. Use the attention focuses from `references/property-discovery.md` to look for new properties inspired by triage findings
 4. Update the relevant files in the scratchbook
+5. Write evidence files for new properties to `antithesis/scratchbook/properties/{slug}.md`
+6. Update `antithesis/scratchbook/property-relationships.md` with any new clusters or connections
 
 ## General Guidance
 
@@ -111,6 +117,8 @@ Use the `antithesis-documentation` skill to ground Antithesis-specific terminolo
 - `antithesis/scratchbook/sut-analysis.md`
 - `antithesis/scratchbook/property-catalog.md`
 - `antithesis/scratchbook/deployment-topology.md`
+- `antithesis/scratchbook/property-relationships.md`
+- `antithesis/scratchbook/properties/{slug}.md` (one per cataloged property)
 
 These outputs should be concrete enough for the `antithesis-setup` skill and the `antithesis-workload` skill to use directly.
 
@@ -122,9 +130,13 @@ Review criteria:
 
 - `antithesis/scratchbook/sut-analysis.md` exists and covers architecture, state management, concurrency model, and failure-prone areas
 - `antithesis/scratchbook/property-catalog.md` exists and lists concrete, testable properties — not vague goals like "test failover"
+- Each property has a descriptive kebab-case slug as its canonical ID
 - Each property has a priority and a rationale for its chosen Antithesis assertion type (`Always`, `Sometimes`, `Reachable`, etc.)
 - Properties that need internal branch guidance or replay anchors call out likely SUT-side instrumentation points, not just workload-visible checks
 - `antithesis/scratchbook/deployment-topology.md` exists and describes a minimal container topology — every container is justified
+- Every cataloged property has a corresponding evidence file at `antithesis/scratchbook/properties/{slug}.md` that captures the evidence trail, relevant code paths, and key observations
+- `antithesis/scratchbook/property-relationships.md` exists and groups related properties into clusters with brief notes on suspected connections and dominance
+- Every property slug referenced in `property-relationships.md` corresponds to a property in the catalog
 - Properties focus on timing-sensitive, concurrency-sensitive, and partial-failure scenarios where Antithesis is strongest
 - Claimed guarantees from docs, comments, or issues are represented as properties
 - Assumptions and open questions are recorded in the scratchbook, not left implicit

--- a/antithesis-research/references/property-catalog.md
+++ b/antithesis-research/references/property-catalog.md
@@ -29,10 +29,12 @@ A recently-fixed bug is a great Antithesis test because the fix may not cover al
 
 ## Property Catalog Format
 
+Each property has a unique **slug** — a descriptive, kebab-case identifier (e.g., `acked-writes-survive`, `no-split-brain`). The slug is the canonical ID for the property, used as the catalog heading, the evidence filename (`properties/{slug}.md`), and the identifier in the property relationships file.
+
 For each property, document:
 
 ```
-### [ID]. [Property Name]
+### [slug] — [Property Name]
 
 | | |
 |---|---|
@@ -42,6 +44,8 @@ For each property, document:
 | **Antithesis Angle** | How does fault injection interact with this? What timing/interleaving does it explore? |
 | **Why It Matters** | Real-world impact. Link to issues if applicable. |
 ```
+
+For every property in the catalog, write a corresponding evidence file at `properties/{slug}.md`. See the "Evidence Files" section below.
 
 ## Choosing the Right Antithesis Assertion
 
@@ -84,6 +88,23 @@ Organize properties into categories based on system architecture. Common categor
 
 Each category should have a brief description explaining what area of the system it covers and why it matters.
 
+## Evidence Files
+
+Every property in the catalog must have a corresponding evidence file at `antithesis/scratchbook/properties/{slug}.md`. These files capture the context and reasoning behind each property — information that would otherwise be lost when findings are compressed into catalog entries.
+
+Evidence files are freeform markdown. Write whatever context would help a future reader understand why this property was identified and what code is involved. Typical content includes:
+
+- What led to identifying this property (code patterns, bug history, claimed guarantees, documentation)
+- Specific files and functions involved in the property
+- What goes wrong if the property is violated
+- Anything that would be expensive to rediscover (timing windows, configuration dependencies, subtle interactions)
+
+When you encounter questions you can't answer within the scope of discovery, include them in the evidence file — but don't just state the question. Capture why the question matters and what changes depending on the answer. For example, don't write "Does `fsmRestore()` enforce monotonicity?" Write "Does `fsmRestore()` enforce monotonicity? If not, a crash between `db.Swap()` and `fsmIdx.Store()` could cause index regression, which means the invariant statement needs to account for the restore path. If yes, the property is stronger than stated and the instrumentation can be simpler." A downstream investigator who reads this knows what to look for and how to update the property based on what they find.
+
+The goal is to preserve what you already know from your analysis. Don't do additional deep research for the evidence file — capture what you learned during discovery.
+
 ## Output
 
 Write the catalog to `antithesis/scratchbook/property-catalog.md`.
+Write per-property evidence files to `antithesis/scratchbook/properties/{slug}.md`.
+Write the property relationships to `antithesis/scratchbook/property-relationships.md`.

--- a/antithesis-research/references/property-discovery.md
+++ b/antithesis-research/references/property-discovery.md
@@ -110,8 +110,14 @@ Spawn one agent per focus. Each agent receives:
 Each agent returns:
 
 - Properties in catalog format (may be empty)
-- A brief note on what areas of the codebase it examined
-- Assumptions made or open questions encountered
+- Per-property evidence: for each property, the specific code paths examined
+  (files, functions, line numbers), the failure scenario, key observations, and
+  any open questions with context on why they matter and what the answer would
+  change. This per-property evidence is the primary input for writing evidence
+  files during synthesis — capture everything a future reader would need to
+  understand why this property was identified and how the code is involved.
+- A brief note on what areas of the codebase it examined beyond specific properties
+- Assumptions made that affect multiple properties
 
 ### Synthesis
 
@@ -124,9 +130,21 @@ After all agents complete, synthesize into a single property catalog:
 - **Resolve conflicts:** When agents disagree on assertion type or priority for
   the same property, evaluate which reasoning is stronger. Note the disagreement
   and resolution in the property's rationale.
-- **Renumber and organize:** Assign final IDs and group into categories per the
-  catalog format.
+- **Assign slugs and organize:** Assign a descriptive kebab-case slug to each
+  property and group into categories per the catalog format. The slug is the
+  canonical ID — see `references/property-catalog.md` for details.
 - **Record provenance:** For each property, note which focus(es) surfaced it.
+- **Write evidence files:** For each property, write an evidence file to
+  `properties/{slug}.md` in the scratchbook. Capture the supporting evidence,
+  relevant code paths, failure scenario, and key observations from the agent
+  outputs. These files are freeform markdown — write whatever context would help
+  a future reader understand why this property was identified and what code is
+  involved.
+- **Write property relationships:** Review the complete property set and write
+  `property-relationships.md` in the scratchbook. Group properties that share
+  evidence, code paths, or failure mechanisms into clusters. Note any suspected
+  dominance (where one property likely implies another). This is lightweight —
+  flag connections you noticed during synthesis, don't do deep analysis.
 
 ## Single-Agent Mode
 
@@ -139,7 +157,18 @@ focuses as a sequential checklist:
    focus yields nothing for this system, note why and move on.
 3. After all 10 passes, review the full catalog for duplicates, gaps, and
    consistency.
-4. Organize into final form per the catalog format.
+4. Assign a descriptive kebab-case slug to each property and organize into final
+   form per the catalog format.
+5. For each property, write an evidence file to `properties/{slug}.md` in the
+   scratchbook. Capture the supporting evidence, relevant code paths, failure
+   scenario, and key observations you encountered during your passes. Write
+   whatever context would help a future reader understand why this property was
+   identified and what code is involved.
+6. Review the complete property set and write `property-relationships.md` in the
+   scratchbook. Group properties that share evidence, code paths, or failure
+   mechanisms into clusters. Note any suspected dominance relationships. This is
+   lightweight — flag connections you noticed during the passes, don't do deep
+   analysis.
 
 Treat each pass as a fresh examination. Resist the pull to skip a focus because
 earlier passes "already covered" that area — the point is to look at the same code
@@ -147,5 +176,8 @@ from different angles.
 
 ## Output
 
-The output feeds into `antithesis/scratchbook/property-catalog.md` using the
-format defined in `references/property-catalog.md`.
+- `antithesis/scratchbook/property-catalog.md` — using the format defined in
+  `references/property-catalog.md`
+- `antithesis/scratchbook/properties/{slug}.md` — one per cataloged property
+- `antithesis/scratchbook/property-relationships.md` — suspected clusters and
+  connections

--- a/antithesis-research/references/scratchbook-artifacts.md
+++ b/antithesis-research/references/scratchbook-artifacts.md
@@ -1,0 +1,95 @@
+# Scratchbook Artifacts
+
+This document defines the artifact format contract for the Antithesis scratchbook. Skills that produce or consume scratchbook artifacts should reference this document to ensure consistency.
+
+## Artifact Set
+
+The scratchbook lives at `antithesis/scratchbook/` in the target repository and contains:
+
+| Artifact | Producer | Consumers | Purpose |
+|---|---|---|---|
+| `sut-analysis.md` | research | setup, workload | System architecture, components, data flows, failure-prone areas |
+| `deployment-topology.md` | research | setup | Minimal container topology for the Antithesis environment |
+| `property-catalog.md` | research | workload, refinement (future) | Concise, scannable catalog of testable properties with priorities |
+| `property-relationships.md` | research | refinement (future) | Suspected clusters and connections between properties |
+| `properties/{slug}.md` | research | refinement (future) | Per-property evidence trail and context |
+
+## Layout
+
+```
+antithesis/scratchbook/
+  sut-analysis.md
+  deployment-topology.md
+  property-catalog.md
+  property-relationships.md
+  properties/
+    {slug}.md
+    {slug}.md
+    ...
+```
+
+## Property IDs
+
+Each property has a unique identifier called a **slug**. Slugs are descriptive, kebab-case strings (e.g., `acked-writes-survive`, `no-split-brain`, `leader-election-completes`).
+
+The slug is the canonical identifier for a property. It is used consistently as:
+
+- The identifier in the property catalog heading (`### acked-writes-survive — Acknowledged Writes Survive`)
+- The filename for the property's evidence file (`properties/acked-writes-survive.md`)
+- The reference in the property relationships file
+
+This consistency means a slug uniquely identifies a property across all artifacts. There is no separate numeric ID.
+
+## Property Catalog
+
+The property catalog (`property-catalog.md`) is the human-readable summary of all discovered properties. It is designed for scanning and prioritization.
+
+Each property's evidence file lives at `properties/{slug}.md`, where the slug matches the property's heading in the catalog.
+
+See `references/property-catalog.md` for the full format specification.
+
+## Per-Property Evidence Files
+
+Each property in the catalog has a corresponding evidence file at `properties/{slug}.md`. These files capture the context and reasoning behind the property — information that would otherwise be lost when research compresses its findings into the catalog.
+
+Evidence files are freeform markdown. There is no required structure. Typical content includes:
+
+- **Evidence trail** — what led to identifying this property (code patterns, bug history, claimed guarantees, documentation)
+- **Relevant code paths** — specific files and functions involved
+- **Failure scenario** — what goes wrong if this property is violated
+- **Key observations** — anything expensive to rediscover (timing windows, configuration dependencies, subtle interactions)
+
+The purpose is to preserve what the research skill already knows so that downstream skills don't have to rediscover it.
+
+## Property Relationships
+
+The property relationships file (`property-relationships.md`) groups properties into suspected clusters based on shared evidence, code paths, or failure mechanisms. It also notes suspected dominance relationships (where one property likely implies another).
+
+This file is lightweight — research flags connections it noticed during discovery without doing deep analysis. Confirming or rejecting these relationships is the job of a future refinement skill.
+
+### Format
+
+```markdown
+# Property Relationships
+
+## [Cluster Name]
+Properties: slug-a, slug-b, slug-c
+Notes: Brief explanation of why these properties are related.
+Any suspected dominance or dependency relationships.
+
+## [Cluster Name]
+Properties: slug-d, slug-e
+Notes: ...
+```
+
+### What to Capture
+
+- Properties that share the same underlying code path or failure mechanism
+- Properties where one likely implies another (suspected dominance)
+- Properties that represent different facets of the same system behavior (e.g., safety and liveness sides of the same protocol)
+- Properties with causal dependencies (A is a precondition for B)
+
+### What Not to Capture
+
+- Properties that are merely in the same category (e.g., both are "data integrity" properties) but don't share evidence or code paths
+- Deep analysis of whether dominance actually holds — that requires deeper investigation than research provides

--- a/antithesis-research/references/scratchbook-setup.md
+++ b/antithesis-research/references/scratchbook-setup.md
@@ -23,5 +23,9 @@ All research outputs should be written as markdown files in the Antithesis scrat
 - `antithesis/scratchbook/sut-analysis.md` — System architecture, components, data flows, and attack surfaces
 - `antithesis/scratchbook/property-catalog.md` — Catalog of testable properties with priorities and scoring
 - `antithesis/scratchbook/deployment-topology.md` — Container topology plan for the Antithesis environment
+- `antithesis/scratchbook/property-relationships.md` — Suspected clusters and connections between properties
+- `antithesis/scratchbook/properties/{slug}.md` — Per-property evidence files (one per cataloged property)
 
 When starting from scratch, initialize each file with a short summary section plus explicit `Assumptions` and `Open Questions` headings. This makes later iterations and handoffs easier.
+
+Create the `antithesis/scratchbook/properties/` directory when writing the first property evidence file.

--- a/antithesis-setup/assets/antithesis/AGENTS.md
+++ b/antithesis-setup/assets/antithesis/AGENTS.md
@@ -15,7 +15,7 @@ Inject this script into a Dockerfile to notify Antithesis that setup is complete
 This directory contains the `docker-compose.yaml` file used to bring up this system within the Antithesis environment, along with any closely related config files. Snouty will push tagged images, consume this config directory, and launch the run.
 
 **scratchbook**
-This directory is the Antithesis scratchbook for the codebase. It contains documents such as system analysis, property catalogs, topology plans, and other persistent integration notes. Keep it up to date as Antithesis-related decisions change.
+This directory is the Antithesis scratchbook for the codebase. It contains documents such as system analysis, property catalogs, topology plans, per-property evidence files (in `scratchbook/properties/`), property relationship maps, and other persistent integration notes. Keep it up to date as Antithesis-related decisions change.
 
 **test**
 This directory contains test templates. A test template is a directory containing test command executable files. Each test command must have a valid prefix: `parallel_driver_, singleton_driver_, serial_driver_, first_, eventually_, finally_, anytime_`. Prefixes constrain when and how commands are composed in a single timeline. Files or subdirectories prefixed with `helper_` are ignored by Test Composer and can be used for helper scripts kept alongside the commands.


### PR DESCRIPTION
The research skill's property catalog compresses away the evidence and reasoning behind each property. When downstream skills (or a future refinement skill) need that context, they have to rediscover it from scratch.

This adds two new artifacts to the research skill's output:
- **Per-property evidence files** (`properties/{slug}.md`) that capture the evidence trail, relevant code paths, and key observations
- **A property relationships file** that maps suspected clusters, shared evidence, and dominance between properties

Also:
- Switches property IDs from numeric to descriptive kebab-case slugs that double as filenames and cross-references across artifacts
- Adds guidance on contextualizing open questions in evidence files (capture why the question matters and what the answer would change, not just the question)
- Tightens ensemble agent output format to explicitly require per-property evidence, not just aggregate notes
- Adds a shared artifact format contract document (`scratchbook-artifacts.md`) to research's references

Design: #61, #62, #63, #64