### PR TITLE
Add open question investigation to research, wire evidence files to workload

### DIFF
--- a/antithesis-research/SKILL.md
+++ b/antithesis-research/SKILL.md
@@ -135,9 +135,10 @@ Review criteria:
 - Properties that need internal branch guidance or replay anchors call out likely SUT-side instrumentation points, not just workload-visible checks
 - `antithesis/scratchbook/deployment-topology.md` exists and describes a minimal container topology — every container is justified
 - Every cataloged property has a corresponding evidence file at `antithesis/scratchbook/properties/{slug}.md` that captures the evidence trail, relevant code paths, and key observations
+- Open questions in evidence files have been investigated and resolved — no unresolved questions remain in evidence files for active properties
+- Properties invalidated by investigation are marked in the catalog with the reason
 - `antithesis/scratchbook/property-relationships.md` exists and groups related properties into clusters with brief notes on suspected connections and dominance
 - Every property slug referenced in `property-relationships.md` corresponds to a property in the catalog
 - Properties focus on timing-sensitive, concurrency-sensitive, and partial-failure scenarios where Antithesis is strongest
 - Claimed guarantees from docs, comments, or issues are represented as properties
-- Assumptions and open questions are recorded in the scratchbook, not left implicit
 - The outputs are concrete enough for `antithesis-setup` and `antithesis-workload` to use directly — no ambiguous steps or missing details

--- a/antithesis-research/references/property-discovery.md
+++ b/antithesis-research/references/property-discovery.md
@@ -145,6 +145,16 @@ After all agents complete, synthesize into a single property catalog:
   evidence, code paths, or failure mechanisms into clusters. Note any suspected
   dominance (where one property likely implies another). This is lightweight —
   flag connections you noticed during synthesis, don't do deep analysis.
+- **Investigate open questions:** For each property that has open questions in
+  its evidence file, spawn an agent to investigate. Run these in parallel — one
+  agent per property with open questions. Each agent receives the evidence file
+  and codebase access. The agent reads the evidence file's explanation of why
+  each question matters, investigates the code to answer it, and returns an
+  updated evidence file with questions resolved. If the answer changes the
+  property (different invariant, different assertion type, property invalidated),
+  the updated evidence file reflects that. After all agents return, write the
+  updated evidence files to the scratchbook. If any property was invalidated,
+  mark it in the catalog with the reason.
 
 ## Single-Agent Mode
 
@@ -169,6 +179,12 @@ focuses as a sequential checklist:
    mechanisms into clusters. Note any suspected dominance relationships. This is
    lightweight — flag connections you noticed during the passes, don't do deep
    analysis.
+7. For each property with open questions in its evidence file, investigate the
+   code to answer them. Read the evidence file's explanation of why each
+   question matters, trace the code to answer it, and update the evidence file
+   with the answer and its implications. If the answer changes the property or
+   invalidates it, update accordingly. Mark invalidated properties in the
+   catalog with the reason.
 
 Treat each pass as a fresh examination. Resist the pull to skip a focus because
 earlier passes "already covered" that area — the point is to look at the same code

--- a/antithesis-workload/SKILL.md
+++ b/antithesis-workload/SKILL.md
@@ -19,7 +19,7 @@ keywords:
 
 Implement or improve the Antithesis workload. Success means:
 
-- Properties from the `antithesis-research` skill are mapped to concrete assertions
+- Properties from the `antithesis-research` skill are mapped to concrete assertions, using both the property catalog and per-property evidence files
 - Test commands exist under `antithesis/test/` and exercise the right behaviors
 - The first real test templates are created after setup, or existing ones are expanded
 - Triage findings turn into workload or property updates instead of staying implicit
@@ -34,7 +34,9 @@ Use the `antithesis-research` skill first to build the property catalog. Use the
 
 # Scoping
 
-Start from the existing Antithesis scratchbook, test code, and triage artifacts first. Ask the user only for blockers or scoping decisions you cannot infer safely, such as:
+Start from the existing Antithesis scratchbook, test code, and triage artifacts first. For each property being implemented, read both the catalog entry and the corresponding evidence file at `antithesis/scratchbook/properties/{slug}.md`. The evidence file contains the detailed context — code paths, failure scenarios, instrumentation points, and key observations — that the catalog entry summarizes.
+
+Ask the user only for blockers or scoping decisions you cannot infer safely, such as:
 
 - The property catalog location, if it is not the standard `antithesis/scratchbook/property-catalog.md`
 - Which properties to implement, if the request is narrower than the full catalog

--- a/antithesis-workload/references/assertions.md
+++ b/antithesis-workload/references/assertions.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-Map each property in the catalog to a concrete Antithesis SDK assertion. Some assertions belong in workload code; others belong inside the SUT.
+Map each property in the catalog to a concrete Antithesis SDK assertion. For each property, read the evidence file at `antithesis/scratchbook/properties/{slug}.md` alongside the catalog entry. The evidence file contains the specific code paths, failure scenarios, instrumentation points, and key observations that inform assertion design. Some assertions belong in workload code; others belong inside the SUT.
 
 ## Match the Assertion to the Property Type
 

--- a/antithesis-workload/references/iteration.md
+++ b/antithesis-workload/references/iteration.md
@@ -26,7 +26,7 @@ After running `antithesis-triage` on a completed test run and reviewing the resu
 
 ## Update the Antithesis scratchbook
 
-Update `antithesis/scratchbook/property-catalog.md` whenever properties are added or changed.
+Update `antithesis/scratchbook/property-catalog.md` whenever properties are added or changed. For new properties, write a corresponding evidence file at `antithesis/scratchbook/properties/{slug}.md`. For changed properties, update the existing evidence file to reflect the new understanding.
 
 ## Cross-Reference
 


### PR DESCRIPTION
Two changes that complete the research → workload evidence pipeline:

**Research: investigation step after synthesis**

Research evidence files sometimes contain unresolved questions about code behavior that the discovery process couldn't answer within its scope. This adds an investigation step after synthesis: for each property with open questions, a sub-agent reads the evidence file, investigates the code, and returns an updated evidence file with findings resolved. Properties invalidated by investigation are marked in the catalog. Runs one agent per property with open questions, in parallel, in both ensemble and single-agent modes. Self-review criteria updated to check that no unresolved questions remain.

**Workload: consume evidence files**

The workload skill now reads per-property evidence files (`antithesis/scratchbook/properties/{slug}.md`) alongside the property catalog. Evidence files contain the detailed context the workload skill needs — specific code paths, failure scenarios, instrumentation points, and key observations — that catalog entries only summarize. Updated the scoping section, assertions reference, and iteration reference.