### PR TITLE
Track property catalog provenance via YAML frontmatter

### DIFF
--- a/antithesis-research/SKILL.md
+++ b/antithesis-research/SKILL.md
@@ -129,7 +129,7 @@ Before declaring this skill complete, review your work against the criteria belo
 Review criteria:
 
 - `antithesis/scratchbook/sut-analysis.md` exists and covers architecture, state management, concurrency model, and failure-prone areas
-- `antithesis/scratchbook/property-catalog.md` exists and lists concrete, testable properties — not vague goals like "test failover"
+- `antithesis/scratchbook/property-catalog.md` exists, has provenance frontmatter (`commit` and `updated`), and lists concrete, testable properties — not vague goals like "test failover"
 - Each property has a descriptive kebab-case slug as its canonical ID
 - Each property has a priority and a rationale for its chosen Antithesis assertion type (`Always`, `Sometimes`, `Reachable`, etc.)
 - Properties that need internal branch guidance or replay anchors call out likely SUT-side instrumentation points, not just workload-visible checks

--- a/antithesis-research/references/property-catalog.md
+++ b/antithesis-research/references/property-catalog.md
@@ -1,5 +1,21 @@
 # Property Catalog
 
+## Provenance
+
+The property catalog is a snapshot — it reflects the codebase at the time of analysis. Record this provenance as YAML frontmatter at the very beginning of the output file, before any heading. This lets downstream consumers know what state the catalog reflects.
+
+```yaml
+---
+commit: <full git SHA of the codebase at time of analysis>
+updated: <ISO 8601 date of the analysis>
+---
+```
+
+- **`commit`**: The HEAD commit of the target repository when the catalog was generated or last updated. Use the full 40-character SHA.
+- **`updated`**: The date the catalog was written or last updated. ISO 8601 format (`YYYY-MM-DD`).
+
+When updating an existing catalog (adding properties, revising after triage), update both fields to reflect the current codebase state.
+
 ## Property Types
 
 - **Safety (correctness):** A bad thing never happens.
@@ -105,6 +121,6 @@ The goal is to preserve what you already know from your analysis. Don't do addit
 
 ## Output
 
-Write the catalog to `antithesis/scratchbook/property-catalog.md`.
+Write the catalog to `antithesis/scratchbook/property-catalog.md`. Include the provenance frontmatter (see "Provenance" section above).
 Write per-property evidence files to `antithesis/scratchbook/properties/{slug}.md`.
 Write the property relationships to `antithesis/scratchbook/property-relationships.md`.

--- a/antithesis-research/references/property-discovery.md
+++ b/antithesis-research/references/property-discovery.md
@@ -193,7 +193,8 @@ from different angles.
 ## Output
 
 - `antithesis/scratchbook/property-catalog.md` — using the format defined in
-  `references/property-catalog.md`
+  `references/property-catalog.md`, including provenance frontmatter with the
+  current git commit hash and date
 - `antithesis/scratchbook/properties/{slug}.md` — one per cataloged property
 - `antithesis/scratchbook/property-relationships.md` — suspected clusters and
   connections

--- a/antithesis-research/references/scratchbook-artifacts.md
+++ b/antithesis-research/references/scratchbook-artifacts.md
@@ -44,9 +44,9 @@ This consistency means a slug uniquely identifies a property across all artifact
 
 The property catalog (`property-catalog.md`) is the human-readable summary of all discovered properties. It is designed for scanning and prioritization.
 
-Each property's evidence file lives at `properties/{slug}.md`, where the slug matches the property's heading in the catalog.
+The catalog carries YAML frontmatter that records provenance — the git commit and date of the codebase it was analyzed against. See `references/property-catalog.md` for the frontmatter format and the full catalog specification.
 
-See `references/property-catalog.md` for the full format specification.
+Each property's evidence file lives at `properties/{slug}.md`, where the slug matches the property's heading in the catalog.
 
 ## Per-Property Evidence Files
 

--- a/antithesis-workload/SKILL.md
+++ b/antithesis-workload/SKILL.md
@@ -54,6 +54,8 @@ The detection task: for each property in the catalog, search the existing test a
 
 ## Present and recommend
 
+Note the catalog's provenance frontmatter (`commit` and `updated` fields) and include it when presenting status — e.g., "The property catalog is up-to-date as of `<commit short hash>` (`<date>`)." This lets the user judge whether the catalog reflects the current codebase or needs re-research.
+
 Show the user the status of each property, then recommend one to implement next. Prefer partially-implemented properties that need completion, then unimplemented properties that cluster with recently implemented ones (see `antithesis/scratchbook/property-relationships.md`), then other high-priority unimplemented properties. Wait for the user to confirm or choose differently before proceeding.
 
 For the chosen property, read both the catalog entry and its evidence file.
@@ -143,6 +145,6 @@ Review criteria:
 - No test command is responsible for Antithesis lifecycle signaling; `setup_complete` is emitted before test commands begin
 - Test templates are structured correctly at the path that will map to `/opt/antithesis/test/v1/{name}/` in the container
 - Helper files or directories are prefixed with `helper_` so Test Composer ignores them
-- `antithesis/scratchbook/property-catalog.md` is updated to reflect the implementation status of every property in scope
+- `antithesis/scratchbook/property-catalog.md` is updated to reflect the implementation status of every property in scope, with provenance frontmatter (`commit` and `updated`) reflecting the current codebase state
 - Assertions are in workload code or surgical SUT locations — not scattered across production paths
 - Use `snouty validate` on `antithesis/config` to ensure that the compose setup can reach setup complete and any configured test-templates work. Make sure to build the latest images before running validate.

--- a/antithesis-workload/references/iteration.md
+++ b/antithesis-workload/references/iteration.md
@@ -26,7 +26,7 @@ After running `antithesis-triage` on a completed test run and reviewing the resu
 
 ## Update the Antithesis scratchbook
 
-Update `antithesis/scratchbook/property-catalog.md` whenever properties are added or changed. For new properties, write a corresponding evidence file at `antithesis/scratchbook/properties/{slug}.md`. For changed properties, update the existing evidence file to reflect the new understanding.
+Update `antithesis/scratchbook/property-catalog.md` whenever properties are added or changed — including the provenance frontmatter (`commit` and `updated` fields) so the catalog reflects the current codebase state. For new properties, write a corresponding evidence file at `antithesis/scratchbook/properties/{slug}.md`. For changed properties, update the existing evidence file to reflect the new understanding.
 
 ## Cross-Reference
 


### PR DESCRIPTION
The property catalog is a point-in-time snapshot of codebase analysis, but nothing records when or against what codebase state it was produced. This makes drift invisible — the codebase moves and the catalog silently goes stale.

Adds `commit` and `updated` fields as YAML frontmatter to the catalog format. The research skill populates them when writing or updating the catalog, and the workload skill surfaces them when presenting status so the user can judge staleness. Informational only — no automated gates, since even adding tests moves the commit hash forward.

Changes across 6 files:
- **property-catalog.md** — new Provenance section defining the frontmatter format and placement
- **scratchbook-artifacts.md** — artifact contract updated to mention frontmatter
- **property-discovery.md** — output instructions include populating provenance
- **iteration.md** — catalog update instructions include updating provenance
- **research SKILL.md** — self-review criteria check for provenance frontmatter
- **workload SKILL.md** — "Present and recommend" surfaces provenance to user; self-review checks it

Closes #68