### PR TITLE
feat: add pass/fail example counts to property results

### DIFF
--- a/antithesis-triage/assets/antithesis-triage.js
+++ b/antithesis-triage/assets/antithesis-triage.js
@@ -1,5 +1,5 @@
 (function () {
-  var VERSION = "1.1.0";
+  var VERSION = "1.2.0";
 
   function clean(text) {
     return (text || "").replace(/\s+/g, " ").trim();
@@ -358,6 +358,16 @@
     }
   }
 
+  function exampleCounts(container) {
+    var text = clean(container.textContent);
+    var match = text.match(/([\d,]+)\s+passing\s+example.*?([\d,]+)\s+failing\s+example/);
+    if (!match) return { passingCount: null, failingCount: null };
+    return { passingCount: match[1], failingCount: match[2] };
+  }
+
+  // Assumes leaf properties are already expanded by the caller (getAllProperties
+  // and getFilteredProperties both expand all containers before calling this).
+  // Pass/fail example counts are only present in the DOM after expansion.
   function visibleLeafProperties(filterStatus) {
     return visiblePropertyContainers()
       .filter(function (container) {
@@ -365,10 +375,13 @@
         return !filterStatus || containerStatus(container) === filterStatus;
       })
       .map(function (container) {
+        var counts = exampleCounts(container);
         return {
           group: groupPath(container),
           name: nameOf(container),
           status: containerStatus(container),
+          passingCount: counts.passingCount,
+          failingCount: counts.failingCount,
         };
       });
   }

--- a/antithesis-triage/references/properties.md
+++ b/antithesis-triage/references/properties.md
@@ -56,6 +56,57 @@ agent-browser --session "$SESSION" eval \
   "window.__antithesisTriage.report.expandFailedExamples()"
 ```
 
+## Property summary text (pass/fail counts)
+
+When a leaf property is expanded in the report, it shows summary text below the
+property name with the total number of passing and failing examples across the
+entire run. For example:
+
+> On 2026-03-23, 19:59 ... with 3,529 passing examples and 10,409 failing examples
+
+This is distinct from the example rows shown in the table (typically 3-4 rows).
+The summary gives the true ratio across all execution histories in the run.
+
+The runtime methods that return leaf properties (`getAllProperties`,
+`getFailedProperties`, `getPassedProperties`, `getUnfoundProperties`) now
+include `passingCount` and `failingCount` fields on each property object.
+These are comma-formatted count strings (e.g. `"3,529"`) or `null` if the
+property was not expanded or the summary text is absent.
+
+Example:
+
+```bash
+agent-browser --session "$SESSION" eval \
+  "(async () => window.__antithesisTriage.report.getAllProperties())()"
+```
+
+Each property in the returned `properties` array includes:
+
+```json
+{
+  "group": ["SDK: Go"],
+  "name": "example property",
+  "status": "failed",
+  "passingCount": "3,529",
+  "failingCount": "10,409"
+}
+```
+
+### Using pass/fail ratios for triage prioritization
+
+The ratio of passing to failing examples is a strong signal for root cause:
+
+- **All failing (0 passing)** — Almost certainly a setup or workload bug, not a
+  real SUT bug. The property is being violated in every execution history,
+  which means something is systematically wrong with how it's checked.
+- **Mostly failing with rare passes** — Could be a workload issue that only
+  succeeds under specific conditions, or a real bug that's hard to avoid.
+- **Mostly passing with rare failures** — Strong candidate for a real SUT bug.
+  The system usually works but specific fault injection sequences trigger a
+  violation. Investigate the failing examples' logs for fault events.
+- **Roughly even split** — The property may be sensitive to configuration or
+  timing. Check whether passing vs failing correlates with fault intensity.
+
 To expand failed properties and collect their examples in one structured call:
 
 ```bash


### PR DESCRIPTION
Why: Triage skill can reason better about a failure and provide better information to the user if it has access to the pass/fail counts on properties. This PR updates the injected javascript to return that and updates the skill to understand how to interpret the data. For instance, a property that fails every single time is likely a setup issue.

Leaf properties returned by getAllProperties, getFailedProperties, getPassedProperties, and getUnfoundProperties now include passingCount and failingCount fields. These are parsed from the summary text that appears when a property is expanded in the triage report, giving the true ratio across all execution histories in the run.

The reference doc is updated with usage examples and triage prioritization guidance based on pass/fail ratios.