### PR TITLE
Scan for existing SDK assertions before property discovery

### DIFF
--- a/antithesis-research/SKILL.md
+++ b/antithesis-research/SKILL.md
@@ -75,10 +75,18 @@ Use the `antithesis-documentation` skill to ground Antithesis-specific terminolo
 1. Read `references/scratchbook-setup.md`
 2. Read `references/sut-discovery.md` and `references/sut-analysis.md`
 3. Analyze the system using the ensemble or single-agent workflow from `references/sut-discovery.md`
-4. Read `references/property-discovery.md` and `references/property-catalog.md`
-5. Discover properties using the ensemble or single-agent workflow from `references/property-discovery.md`
-6. Read `references/deployment-topology.md`
-7. Write or update all findings in the scratchbook under `antithesis/scratchbook/`
+4. Scan the codebase for existing Antithesis SDK assertions. Search for imports
+   of the Antithesis SDK and calls to assertion functions (`assert_always!`,
+   `assert_sometimes!`, `assert_reachable!`, `assert_unreachable!`, or their
+   non-macro equivalents). For each assertion found, record the file path, line
+   number, assertion type, and message string. Write the results to
+   `antithesis/scratchbook/existing-assertions.md`. If no assertions are found,
+   write the file with a note confirming the codebase has no existing
+   instrumentation.
+5. Read `references/property-discovery.md` and `references/property-catalog.md`
+6. Discover properties using the ensemble or single-agent workflow from `references/property-discovery.md`
+7. Read `references/deployment-topology.md`
+8. Write or update all findings in the scratchbook under `antithesis/scratchbook/`
 
 ### Targeted property research
 
@@ -115,6 +123,7 @@ Use the `antithesis-documentation` skill to ground Antithesis-specific terminolo
 ## Output
 
 - `antithesis/scratchbook/sut-analysis.md`
+- `antithesis/scratchbook/existing-assertions.md`
 - `antithesis/scratchbook/property-catalog.md`
 - `antithesis/scratchbook/deployment-topology.md`
 - `antithesis/scratchbook/property-relationships.md`
@@ -129,6 +138,8 @@ Before declaring this skill complete, review your work against the criteria belo
 Review criteria:
 
 - `antithesis/scratchbook/sut-analysis.md` exists and covers architecture, state management, concurrency model, and failure-prone areas
+- `antithesis/scratchbook/existing-assertions.md` exists and lists all Antithesis SDK assertions found in the codebase (or explicitly states none were found)
+- Evidence files correctly distinguish between instrumentation that already exists in the codebase, instrumentation that is partially present, and instrumentation that is missing — no evidence file suggests adding an assertion that is already there
 - `antithesis/scratchbook/property-catalog.md` exists, has provenance frontmatter (`commit` and `updated`), and lists concrete, testable properties — not vague goals like "test failover"
 - Each property has a descriptive kebab-case slug as its canonical ID
 - Each property has a priority and a rationale for its chosen Antithesis assertion type (`Always`, `Sometimes`, `Reachable`, etc.)

--- a/antithesis-research/references/property-discovery.md
+++ b/antithesis-research/references/property-discovery.md
@@ -13,6 +13,9 @@ properties in the standard catalog format defined in `references/property-catalo
 ## Prerequisites
 
 - `antithesis/scratchbook/sut-analysis.md` exists and is current
+- `antithesis/scratchbook/existing-assertions.md` exists (scan results — may
+  indicate no existing instrumentation, but must be present before agents are
+  spawned)
 
 ## Attention Focuses
 
@@ -98,6 +101,9 @@ Spawn one agent per focus. Each agent receives:
 - The contents of `antithesis/scratchbook/sut-analysis.md`
 - The property catalog format from `references/property-catalog.md`
 - One attention focus (its full description and "look for" guidance from above)
+- The path to `antithesis/scratchbook/existing-assertions.md` — read this before
+  writing evidence files; for each property, note which assertions already exist
+  vs. which are missing
 - These instructions:
 
 > Examine the codebase through the lens of your assigned attention focus. Produce
@@ -116,7 +122,10 @@ kebab-case name for the property. If a file already exists at the chosen name
 code paths examined (files, functions, line numbers), the failure scenario, key
 observations, and any open questions with context on why they matter and what the
 answer would change. Write everything a future reader would need to understand
-why this property was identified and how the code is involved.
+why this property was identified and how the code is involved. For each
+property's SUT-side instrumentation suggestions, cross-reference
+`existing-assertions.md` and explicitly note whether each suggested assertion
+already exists in the codebase, is partially present, or is missing.
 
 **Returned to synthesis:**
 
@@ -157,10 +166,13 @@ After all agents complete, synthesize into a single property catalog:
 - **Investigate open questions:** For each property that has open questions in
   its evidence file, spawn an agent to investigate. Run these in parallel — one
   agent per property with open questions. Each agent receives the path to the
-  evidence file in the scratchbook and codebase access. The agent reads the
-  evidence file's explanation of why each question matters, investigates the code
-  to answer it, and writes the updated evidence file back to the same path with
-  questions resolved. The agent returns a short structured summary (not the full
+  evidence file in the scratchbook, codebase access, and the path to
+  `antithesis/scratchbook/existing-assertions.md`. The agent reads the evidence
+  file's explanation of why each question matters, investigates the code to
+  answer it, and writes the updated evidence file back to the same path with
+  questions resolved — including correcting any instrumentation suggestions
+  against `existing-assertions.md` to accurately reflect what already exists vs.
+  what is missing. The agent returns a short structured summary (not the full
   evidence file) describing: which questions were resolved, whether the property
   changed (different invariant, different assertion type), and whether the
   property was invalidated with the reason. After all agents return, review the
@@ -173,29 +185,33 @@ If your environment does not support sub-agents, work through the attention
 focuses as a sequential checklist:
 
 1. Read the SUT analysis.
-2. For each attention focus in order, make an explicit pass through the codebase
+2. Read `antithesis/scratchbook/existing-assertions.md` so you have the full
+   picture of what's already instrumented before writing any evidence files.
+3. For each attention focus in order, make an explicit pass through the codebase
    with that lens. After each pass, add new properties to a running catalog. If a
    focus yields nothing for this system, note why and move on.
-3. After all 10 passes, review the full catalog for duplicates, gaps, and
+4. After all 10 passes, review the full catalog for duplicates, gaps, and
    consistency.
-4. Assign a descriptive kebab-case slug to each property and organize into final
+5. Assign a descriptive kebab-case slug to each property and organize into final
    form per the catalog format.
-5. For each property, write an evidence file to `properties/{slug}.md` in the
+6. For each property, write an evidence file to `properties/{slug}.md` in the
    scratchbook. Capture the supporting evidence, relevant code paths, failure
-   scenario, and key observations you encountered during your passes. Write
-   whatever context would help a future reader understand why this property was
-   identified and what code is involved.
-6. Review the complete property set and write `property-relationships.md` in the
+   scenario, and key observations you encountered during your passes. For each
+   property's SUT-side instrumentation suggestions, cross-reference
+   `existing-assertions.md` and explicitly note whether each suggested assertion
+   already exists in the codebase, is partially present, or is missing.
+7. Review the complete property set and write `property-relationships.md` in the
    scratchbook. Group properties that share evidence, code paths, or failure
    mechanisms into clusters. Note any suspected dominance relationships. This is
    lightweight — flag connections you noticed during the passes, don't do deep
    analysis.
-7. For each property with open questions in its evidence file, investigate the
+8. For each property with open questions in its evidence file, investigate the
    code to answer them. Read the evidence file's explanation of why each
    question matters, trace the code to answer it, and update the evidence file
-   with the answer and its implications. If the answer changes the property or
-   invalidates it, update accordingly. Mark invalidated properties in the
-   catalog with the reason.
+   with the answer and its implications — including correcting any instrumentation
+   suggestions against `existing-assertions.md`. If the answer changes the
+   property or invalidates it, update accordingly. Mark invalidated properties
+   in the catalog with the reason.
 
 Treat each pass as a fresh examination. Resist the pull to skip a focus because
 earlier passes "already covered" that area — the point is to look at the same code


### PR DESCRIPTION
## Summary

Fixes #79.

When the research skill runs on a repo that already uses the Antithesis SDK, discovery and investigation agents were suggesting instrumentation that already exists in the codebase — confusing output that erodes trust in the results.

- Add a scan step (step 4 in the full research pass) that searches the codebase for existing assertion calls and writes results to `antithesis/scratchbook/existing-assertions.md` before any agents are spawned
- Discovery agents receive the path to this file and cross-reference it when writing evidence files, classifying each instrumentation point as already present, partial, or missing
- Investigation agents also receive it and correct instrumentation suggestions when resolving open questions
- Single-agent mode reads it before any passes begin
- Self-review criteria updated to check the file exists and that evidence files correctly classify existing vs. missing assertions

## Test plan

- [ ] Run the research skill against the ReadySet repo (as suggested in #79) and verify `existing-assertions.md` is produced
- [ ] Verify evidence files correctly classify existing assertions as present rather than suggesting they be added
- [ ] Verify the skill works correctly on a repo with no existing Antithesis instrumentation (file produced with "none found" note)

🤖 Generated with [Claude Code](https://claude.com/claude-code)