### PR TITLE
feat: add container field to log event extraction

### DIFF
--- a/antithesis-triage/SKILL.md
+++ b/antithesis-triage/SKILL.md
@@ -271,7 +271,7 @@ again.
 - **Do not overlap navigation with queries.** `agent-browser eval` calls can fail with an execution-context-destroyed error if the report is still navigating or hydrating.
 - **Logs require full auth.** Navigating to log pages requires a fully authenticated session.
 - **Logs use virtual scrolling.** Only ~50-70 rows render at a time. You may need to scroll to find specific entries.
-- **Present results clearly.** When reporting property statuses, use a table or list. When reporting log findings, include the virtual timestamp, source, and log text.
+- **Present results clearly.** When reporting property statuses, use a table or list. When reporting log findings, include the virtual timestamp, source, container, and log text.
 
 ## Self-Review
 

--- a/antithesis-triage/assets/antithesis-triage.js
+++ b/antithesis-triage/assets/antithesis-triage.js
@@ -1,5 +1,5 @@
 (function () {
-  var VERSION = "1.2.0";
+  var VERSION = "1.3.0";
 
   function clean(text) {
     return (text || "").replace(/\s+/g, " ").trim();
@@ -1128,6 +1128,7 @@
         .map(function (ev) {
           return {
             vtime: lastText(ev.querySelector(".event__vtime")),
+            container: lastText(ev.querySelector(".event__container")),
             source: lastText(ev.querySelector(".event__source_name")),
             text: extractLogEvent(ev),
             highlighted: ev.classList.contains("_emphasized_blue"),
@@ -1156,6 +1157,7 @@
       return events.slice(start, end).map(function (ev) {
         return {
           vtime: lastText(ev.querySelector(".event__vtime")),
+          container: lastText(ev.querySelector(".event__container")),
           source: lastText(ev.querySelector(".event__source_name")),
           text: extractLogEvent(ev),
           highlighted: ev.classList.contains("_emphasized_blue"),

--- a/antithesis-triage/references/logs.md
+++ b/antithesis-triage/references/logs.md
@@ -80,9 +80,11 @@ agent-browser --session "$SESSION" eval \
 
 ## Read visible log entries
 
-Each `.event` element contains tooltip children (`<a-tooltip>`) followed by a
-text node with the actual value. Use `lastText()` to extract the visible text,
-skipping tooltip prefixes.
+Each log event has four columns: virtual time, source (command name), container,
+and message text. The runtime methods extract these into objects with fields
+`vtime`, `container`, `source`, `text`, and `highlighted`. The `container` field
+identifies which Docker container produced the event (e.g., `nsq-workload-2`),
+which is important for correlating faults with errors in multi-container setups.
 
 ```bash
 agent-browser --session "$SESSION" eval \


### PR DESCRIPTION
Add "container" to what the triage skill pulls out of the event log in triage reports. This builds on the change to the js to get pass/fail counts. Update the injected js plus the instructions to the agent on what to do with this.