### PR TITLE
feat: improve triage log reading and property navigation

### DIFF
--- a/.github/workflows/pr-skill-context.yml
+++ b/.github/workflows/pr-skill-context.yml
@@ -20,6 +20,9 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - name: Run strip-log-escapes tests
+        run: python3 antithesis-triage/assets/strip-log-escapes.py --test
+
       - name: Check spelling
         uses: crate-ci/typos@v1.44.0
 

--- a/antithesis-setup/SKILL.md
+++ b/antithesis-setup/SKILL.md
@@ -61,13 +61,25 @@ This skill is broken out into multiple steps, each in a different reference file
 - Merge with existing `antithesis/` content instead of overwriting it.
 - Prefer `podman compose` for local testing; fall back to `docker compose`.
 - Keep Antithesis-only scaffolding under `antithesis/` when practical.
-- Focus this skill on infrastructure and readiness, not on defining the workload itself.
-- Installing the relevant Antithesis SDK into the SUT and adding one minimal bootstrap assertion is part of setup, not deferred workload work.
-- If `antithesis/test/` does not exist yet, create the directory structure needed for later workload work, but leave real test templates and assertions to `antithesis-workload`.
-- Treat instrumentation and symbolization as bootstrap work. The setup is not complete until the relevant images expose `/opt/antithesis/catalog/` or `/symbols/` correctly for their language.
+- Focus this skill on infrastructure and readiness, not on defining the workload
+  itself.
+- Installing the relevant Antithesis SDK into the SUT and adding one minimal
+  bootstrap assertion is part of setup, not deferred workload work.
+- If `antithesis/test/` does not exist yet, create the directory structure
+  needed for later workload work, but leave real test templates and assertions
+  to `antithesis-workload`.
+- Treat instrumentation and symbolization as bootstrap work. The setup is not
+  complete until the relevant images expose `/opt/antithesis/catalog/` or
+  `/symbols/` correctly for their language.
 - Treat local testing as required before the first submission.
 - Use `snouty run` directly to submit runs. Run `compose build` before `snouty run` to ensure images are up to date.
-- Do not add a separate Dockerfile under `antithesis/config/` unless the deployment explicitly requires it.
+- Do not add a separate Dockerfile under `antithesis/config/` unless the
+  deployment explicitly requires it.
+- Disable color/ANSI output in every container. Antithesis stores raw bytes and
+  does not render escape codes — color output is garbage in logs and triage. Set
+  `NO_COLOR=1` on all services via docker-compose.yaml environment blocks or
+  Dockerfile `ENV` directives. Add tool-specific flags (e.g. `FORCE_COLOR=0`)
+  where needed.
 
 ## Self-Review
 
@@ -84,4 +96,5 @@ Review criteria:
 - The `setup_complete` signal is wired in at least one entrypoint
 - `snouty validate` on `antithesis/config/` succeeds
 - All built images target `amd64` (verified via `podman image inspect` or `docker image inspect`)
+- Every service has `NO_COLOR=1` set in its environment (via docker-compose.yaml and/or Dockerfile) to prevent ANSI escape codes in container output
 - The harness is ready for the `antithesis-workload` skill — test template directories exist or are wired for later use

--- a/antithesis-setup/assets/antithesis/config/docker-compose.yaml
+++ b/antithesis-setup/assets/antithesis/config/docker-compose.yaml
@@ -6,6 +6,8 @@
 # Local images use `build:` so `compose build` can build them before `snouty run`.
 # Public images (e.g. postgres, redis) use `image:` directly.
 # Every service MUST include `platform: linux/amd64` — Antithesis runs on x86-64.
+# Every service MUST set `NO_COLOR=1` — Antithesis stores raw bytes and does
+# not render ANSI escape codes, so color output is garbage.
 #
 # Example:
 #   name: foobar
@@ -18,14 +20,20 @@
 #         context: ../..           # repo root (relative to this file)
 #         dockerfile: Dockerfile
 #       image: foobar-server:latest
+#       environment:
+#         NO_COLOR: "1"
 #
 #     postgres:
 #       container_name: foobar-postgres
 #       platform: linux/amd64
 #       image: docker.io/library/postgres:17.2
+#       environment:
+#         NO_COLOR: "1"
 
 services:
   noop:
     platform: linux/amd64
     image: busybox:1.36
+    environment:
+      NO_COLOR: "1"
     command: ["sh", "-c", "tail -f /dev/null"]

--- a/antithesis-setup/references/docker-compose.md
+++ b/antithesis-setup/references/docker-compose.md
@@ -24,6 +24,7 @@ Services use one of two patterns:
 Every service must include `platform: linux/amd64` because Antithesis runs on x86-64. This applies to both local and public images — without it, builds and pulls on ARM hosts (e.g. macOS Apple Silicon) will produce the wrong architecture.
 
 Example:
+
 ```yaml
 name: foobar
 

--- a/antithesis-setup/references/docker-images.md
+++ b/antithesis-setup/references/docker-images.md
@@ -51,7 +51,22 @@ services:
 
 If the deployment includes a client or workload image, make sure it can later receive test templates at `/opt/antithesis/test/v1/`. The `antithesis-setup` skill does not need to create real test templates; it only needs to preserve the path and image structure that `antithesis-workload` will use. If helper files later live inside a template, prefix their file or directory names with `helper_` so Test Composer ignores them.
 
+## Disable Color Output
+
+Antithesis collects and stores raw bytes from container output. ANSI escape codes (colors, cursor movement, etc.) are not rendered and appear as garbage in logs and triage output. **Disable color output in every container image.**
+
+Set this environment variable in every Dockerfile (or in docker-compose.yaml environment blocks):
+
+```dockerfile
+ENV NO_COLOR=1
+```
+
+`NO_COLOR` is a widely adopted convention (see https://no-color.org/) honored by most CLI tools, test frameworks, and language runtimes.
+
+Additionally, if the SUT or its dependencies have their own color flags (e.g. `--no-color`, `FORCE_COLOR=0`, `GCC_COLORS=`, `PYTEST_ADDOPTS=--no-header -p no:color`), disable those too. The goal is zero ANSI escape sequences in any container output.
+
 ## Requirements
 
 - All images must target Linux x86-64. Set `platform: linux/amd64` on every service in docker-compose.yaml — both `build:` services and `image:`-only services (public images like postgres will also pull the wrong architecture on ARM hosts without it).
+- All images must disable color/ANSI output. Set `NO_COLOR=1` in every container environment.
 - Follow the Docker best practices guide: `https://antithesis.com/docs/best_practices/docker_best_practices.md`

--- a/antithesis-triage/SKILL.md
+++ b/antithesis-triage/SKILL.md
@@ -253,8 +253,10 @@ again.
 ### Investigate a failing property
 
 1. Read `references/setup-auth.md` — authenticate and open the report
-2. Read `references/properties.md` — list properties, filter to failed, get examples grouped by property
-3. Read `references/logs.md` — navigate to a specific example's `logsUrl`, download the log to a file, and inspect the log file locally.
+2. Read `references/properties.md` — Filter for failed properties or search for
+   the property name. Do not use findings.
+3. Read `references/logs.md` — navigate to a specific example's `logsUrl`,
+   download the log to a file, and inspect the log file locally.
 4. Report the failure with: property name, assertion text, relevant log lines, and the timeline context
 
 **Important:** Do not draw conclusions about why a property failed until you have downloaded and reviewed any attached logs. The property status and assertion text alone are not sufficient — the logs provide the actual runtime context needed to understand the failure.

--- a/antithesis-triage/assets/strip-log-escapes.py
+++ b/antithesis-triage/assets/strip-log-escapes.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Strip ANSI escape codes from output_text fields in an Antithesis JSON log.
+
+Usage: python3 strip-log-escapes.py < events.json > clean.json
+       python3 strip-log-escapes.py events.json -o clean.json
+       python3 strip-log-escapes.py events.json  # prints to stdout
+       python3 strip-log-escapes.py --test       # run unit tests
+"""
+
+import argparse
+import json
+import re
+import sys
+
+ANSI_RE = re.compile(
+    r"\x1b\[[\x20-\x3f]*[\x40-\x7e]"  # CSI: ESC [ ... final
+    r"|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)"  # OSC: ESC ] ... (BEL | ESC \)
+    r"|\x1b[\x20-\x7e]"  # two-byte: ESC + single printable
+)
+
+
+def strip_ansi(text):
+    return ANSI_RE.sub("", text)
+
+
+def strip_event(event):
+    if "output_text" in event and isinstance(event["output_text"], str):
+        event = {**event, "output_text": strip_ansi(event["output_text"])}
+    return event
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Strip ANSI escape codes from output_text fields in an Antithesis JSON log.",
+    )
+    parser.add_argument("input", nargs="?", help="input JSON log (default: stdin)")
+    parser.add_argument("-o", "--output", help="output file (default: stdout)")
+    parser.add_argument("--test", action="store_true", help="run unit tests")
+    args = parser.parse_args()
+
+    if args.test:
+        return run_tests()
+
+    src = open(args.input) if args.input else sys.stdin
+    try:
+        events = json.load(src)
+    finally:
+        if src is not sys.stdin:
+            src.close()
+
+    events = [strip_event(e) for e in events]
+
+    dst = open(args.output, "w") if args.output else sys.stdout
+    try:
+        json.dump(events, dst, ensure_ascii=False)
+        dst.write("\n")
+    finally:
+        if dst is not sys.stdout:
+            dst.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def run_tests():
+    failures = 0
+
+    def check(name, input_text, expected=None):
+        nonlocal failures
+        if expected is None:
+            expected = input_text
+        result = strip_ansi(input_text)
+        if result != expected:
+            print(f"FAIL: {name}")
+            print(f"  input:    {input_text!r}")
+            print(f"  expected: {expected!r}")
+            print(f"  got:      {result!r}")
+            failures += 1
+        else:
+            print(f"  ok: {name}")
+
+    # -- SGR (colors, bold, etc) --
+    check("bold + reset", "\x1b[1mbold\x1b[0m", "bold")
+    check("256 color", "\x1b[38;5;196mred\x1b[0m", "red")
+    check("RGB color", "\x1b[38;2;255;0;0mred\x1b[0m", "red")
+    check("multiple SGR params", "\x1b[1;31;42mtext\x1b[0m", "text")
+    check(
+        "typical tracing-subscriber line",
+        "\x1b[2m2026-04-03T08:19:54Z\x1b[0m \x1b[32m INFO\x1b[0m"
+        " \x1b[2mfoobar\x1b[0m\x1b[2m:\x1b[0m ready",
+        "2026-04-03T08:19:54Z  INFO foobar: ready",
+    )
+
+    # -- CSI non-SGR (cursor, erase, DEC private) --
+    check("cursor up", "before\x1b[2Aafter", "beforeafter")
+    check("erase line", "text\x1b[2K", "text")
+    check("DEC show cursor", "\x1b[?25hvisible", "visible")
+    check("DEC hide cursor", "\x1b[?25l hidden", " hidden")
+
+    # -- OSC sequences --
+    check("OSC window title (BEL terminated)", "\x1b]0;my window title\x07text after", "text after")
+    check("OSC window title (ST terminated)", "\x1b]0;my title\x1b\\text after", "text after")
+
+    # -- Two-byte escapes --
+    check("ESC c (reset)", "\x1bcafter reset", "after reset")
+    check("ESC 7 (save cursor)", "before\x1b7after", "beforeafter")
+
+    # -- Must NOT damage these --
+    check("plain text passthrough", "no escapes here")
+    check("inline JSON preserved", '{"key": "value", "nested": {"a": [1,2,3]}}')
+    check("JSON with special chars", '{"url": "http://example.com/path?q=1&r=2", "count": 42}')
+    check(
+        "Rust Debug struct preserved",
+        'Options { address: Some(0.0.0.0:3307), deployment: "mydb", mode: Standalone }',
+    )
+    check(
+        "Rust Debug with nested braces",
+        'Config { inner: Inner { values: [1, 2, 3] }, name: "test" }',
+    )
+    check("square brackets in text", "[2026-04-03] [INFO] [main] started")
+    check("backslash in paths", 'path: "/nix/store/abc-pkg/bin/cmd"')
+    check("escaped quotes in JSON", '{"msg": "he said \\"hello\\""}')
+
+    # -- Mixed: escapes around JSON/structs --
+    check("escape codes wrapping JSON", '\x1b[2m{"key": "value"}\x1b[0m', '{"key": "value"}')
+    check(
+        "escape codes wrapping Rust Debug",
+        "\x1b[3mOptions { mode: Standalone }\x1b[0m",
+        "Options { mode: Standalone }",
+    )
+    check(
+        "tracing line with JSON payload",
+        "\x1b[2m2026-04-03T00:00:00Z\x1b[0m \x1b[32m INFO\x1b[0m"
+        ' request completed {"status": 200, "latency_ms": 42}',
+        '2026-04-03T00:00:00Z  INFO request completed {"status": 200, "latency_ms": 42}',
+    )
+
+    # -- Event-level tests --
+    def assert_eq(name, got, expected):
+        nonlocal failures
+        if got != expected:
+            print(f"FAIL: {name}")
+            print(f"  expected: {expected!r}")
+            print(f"  got:      {got!r}")
+            failures += 1
+        else:
+            print(f"  ok: {name}")
+
+    evt = {"output_text": "\x1b[1mhi\x1b[0m", "fault": {"name": "kill"}, "other": "\x1b[1mkeep\x1b[0m"}
+    result = strip_event(evt)
+    assert_eq("strip_event strips output_text", result["output_text"], "hi")
+    assert_eq("strip_event does not mutate input", evt["output_text"], "\x1b[1mhi\x1b[0m")
+    assert_eq("strip_event preserves other fields", result["other"], "\x1b[1mkeep\x1b[0m")
+
+    print()
+    if failures:
+        print(f"{failures} test(s) failed")
+        sys.exit(1)
+    else:
+        print("all tests passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/antithesis-triage/references/logs.md
+++ b/antithesis-triage/references/logs.md
@@ -1,6 +1,7 @@
 # Logs
 
-Antithesis renders logs in the web UI using a `div.sequence_printer_wrapper` component.
+Antithesis renders logs in the web UI using a `div.sequence_printer_wrapper`
+component.
 
 Logs can appear in a few places:
 
@@ -13,11 +14,12 @@ Logs can appear in a few places:
    viewer appears on the right side after selecting a candidate moment in the
    search results.
 
-## Downloading logs from a log viewer
+## Downloading logs
 
 ### Check agent-browser version
 
-Downloading logs to a file requires `agent-browser` v0.23.4 or above. Check before attempting a download:
+Downloading logs to a file requires `agent-browser` v0.23.4 or above. Check
+before attempting a download:
 
 ```bash
 agent-browser --version
@@ -40,212 +42,291 @@ agent-browser --session "$SESSION" eval \
 Returns an array with one entry per viewer:
 
 - `index`: zero-based viewer index (pass to `prepareDownload`)
-- `label`: text from the preceding element (e.g., `"Filtered logs:"`) or `null`
+- `label`: text from the preceding element (e.g., `"Filtered logs:"`) or
+  `null`
 - `itemCount`: number of items in the viewer
 - `visible`: whether the viewer is currently rendered
 
-If a desired log viewer is not visible, you may need to expand it's containing section to view it. Look for elements containing `Expand for full, unfiltered logs` or other section headers.
+### Download the logs
 
-### Download logs from a log viewer
+**Default to JSON format.** JSON preserves full event structure — fault data,
+source metadata, and timestamps are all properly typed fields. Use TXT or CSV
+only when explicitely asked for it.
 
-To download logs from a log viewer you need to run two agent-browser commands sequentially. These commands MUST NOT run in parallel as the second depends on the first.
+To download logs from a log viewer, run two `agent-browser` commands
+sequentially. These commands MUST NOT run in parallel as the second depends
+on the first.
 
-First, you need to execute `prepareDownload` specifying which format you want as well as the log viewer index. The first viewer index is 0.
+Step 1 — prepare the download link:
 
 ```bash
 agent-browser --session "$SESSION" eval \
-  'window.__antithesisTriage.logs.prepareDownload("txt", 0)'
+  'window.__antithesisTriage.logs.prepareDownload("json", 0)'
 ```
 
-Then, once that command completes, you need to run download. Download takes two arguments. The first is the selector returned by the previous command, and the second is the output file path on your local filesystem.
+The first argument is the format (`json`, `txt`, or `csv`). The second is the
+viewer index (0 for the first/only viewer).
+
+Step 2 — download the file:
 
 ```bash
 agent-browser --session "$SESSION" download \
   'a.sequence_printer_menu_button[data-triage-dl]' "$OUTPUT_PATH"
 ```
 
-You should download log files using unique names to a temporary directory unless
-a specific directory has been specified by the user. Make sure to generate
-unique names for log files so as to not collide with other processes running on
-the same machine or older log files.
+Step 3 (JSON only) — strip ANSI escape codes. Application `output_text`
+fields contain terminal color codes that break text search and clutter output.
+This rewrites only `output_text` fields, leaving all other event data intact:
 
-The file is written directly to the specified path. For TXT format, each line
-is a log event in the format:
-
-```
-[<vtime>] [<source>] [<stream>] <message>
+```bash
+python3 assets/strip-log-escapes.py "$OUTPUT_PATH" -o "$CLEAN_PATH"
 ```
 
-`[<vtime>]` is the virtual time of the message. Messages from all containers are interleaved into a single global order by their deterministic vtime.
-`[<source>]` represents the source of the log, usually a docker container name for SUT messages.
-`[<stream>]` can be `[err]` which means that this log message is from stderr.
-`<message>` the raw log message, sometimes structured as JSON.
-
-### Supported formats
-
-| Format | `prepareDownload` arg | Download selector filename | Content                                |
-| ------ | --------------------- | -------------------------- | -------------------------------------- |
-| TXT    | `'txt'`               | `events.log`               | One log line per event                 |
-| JSON   | `'json'`              | `events.json`              | JSON array of structured event objects |
-| CSV    | `'csv'`               | `events.csv`               | CSV table                              |
+Use unique filenames in a temporary directory unless the user specifies
+otherwise.
 
 The download is generated client-side from data already loaded in the page —
-no additional network requests are made. Thus you need to ensure that the page is fully loaded before downloading.
+no additional network requests are made. Ensure the page is fully loaded
+before downloading.
 
-## Parsing Logs
+| Format | `prepareDownload` arg | Content                                 |
+| ------ | --------------------- | --------------------------------------- |
+| JSON   | `'json'`              | JSON array of structured event objects  |
+| TXT    | `'txt'`               | One log line per event (human-readable) |
+| CSV    | `'csv'`               | CSV table                               |
 
-When reading logs from an Antithesis run, there are TWO sources of log lines interleaved together:
+## JSON log format
 
-1. **Antithesis system events** — fault injection, container
-   lifecycle, network changes, compose, etc. Example: "fault_injector [host]"
-   where [host] indicates that this is coming from an Antithesis service.
-2. **Customer Application logs** — if it doesn't have [host] it's probably from
-   the customer's applications.
+The JSON download is an array of event objects. Every event has `source` and
+`moment` fields. The remaining fields vary by event type.
 
-### Antithesis Fault Log Format
+### Event schema
 
-Antithesis system-level events appear as structured JSON on stdout. The fault injector logs look like:
-
-Network partition between client and server, so only the connections between those partition groups are faulted. Connections between containers in the same group are not faulted.
-
-```json
+```
 {
-    fault:{
-        affected_nodes:[ALL],
-        details:{
-            asymmetric:true,
-            disruption_type:Slowed,
-            drop_rate:0,
-            latency:{
-                deviation:1597.9999999999998,
-                mean:1492.601977
-            },
-            partitions:[[client],[server]]
-        },
-        max_duration:0.183884736,
-        name:partition,
-        type:network
-    }
+  "source": {
+    "name": string, // e.g. "fault_injector", "container-name", "setup"
+    "stream"?: "info"|"error",
+    "container"?: string // Docker container name, present on app events
+  },
+  "moment": {
+    "_vtime_ticks": number, // virtual time as integer ticks (see below)
+    "input_hash": string,
+    "session_id": string
+  },
+  "output_text"?: string,           // application stdout/stderr line
+  "fault"?: { ... },                // fault injection event
+  "info"?: { ... },                 // fault_injector status
+  "event"?: string,                 // container lifecycle (create/init/start)
+  "antithesis_setup"?: { ... },     // SDK setup-complete signal
+  "command"?: string,               // test composer task lifecycle
+  ...                               // other fields may be included
 }
 ```
 
-Network clog event where any connection to a container listed in `affected_nodes` can experience the `disruption_type` at random times for random durations. If the `affected_nodes` array were empty the fault doesn't actually do anything.
+### Virtual time
 
-```json
-{
-    fault:{
-        affected_nodes:[server, client],
-        details:{
-            disruption_type:Stopped
-        },
-        max_duration:4.515860336,
-        name:clog,
-        type:network
-    }
-}
+Events are globally ordered by `moment._vtime_ticks`, an integer representing
+deterministic virtual time. To convert to seconds divide by `2^32`:
+
+```
+vtime_seconds = _vtime_ticks / 4294967296
 ```
 
-Network restore event which will restore all faulted network links:
+### Event types at a glance
 
-```json
-{
-    fault:{
-        affected_nodes:[ALL],
-        name:restore,
-        type:network
-    }
-}
+| Identifying field(s)             | Source name                | What it is                                  |
+| -------------------------------- | -------------------------- | ------------------------------------------- |
+| `output_text`                    | container name             | Application log line (stdout/stderr)        |
+| `fault`                          | `fault_injector`           | Fault injection event                       |
+| `info`                           | `fault_injector`           | Fault injector status message               |
+| `event`, `image`                 | `containers_meta`          | Container lifecycle (create/init/start/die) |
+| `antithesis_setup`               | `*/sdk.jsonl`              | SDK setup-complete signal                   |
+| `command`, `started_task`        | `antithesis_test_composer` | Test command started                        |
+| `command`, `command_return_code` | `antithesis_test_composer` | Test command finished                       |
+
+### Fault events
+
+Events from `fault_injector` with a `fault` field describe injected faults.
+
+Key fields in `fault`:
+
+- `name`: `partition`, `clog`, `restore`, `kill`, `stop`, `pause`, `throttle`,
+  `skip`
+- `type`: `network`, `node`, `clock`
+- `affected_nodes`: array of container names, or `["ALL"]`
+- `max_duration`: seconds (number) — how long the fault lasts
+- `details`: optional object with fault-specific data (`disruption_type`,
+  `partitions`, `offset`, etc.)
+
+### Application log events (`output_text`)
+
+The `output_text` field contains stdout/stderr lines from SUT containers.
+
+Some applications serialize configuration objects, debug structs, or JSON
+payloads directly into their log messages. These lines can be very long
+(1-4 KB). When presenting logs to the user, consider truncating long
+`output_text` values. When searching, be aware that keyword matches may hit
+these serialized dumps rather than meaningful log messages.
+
+## Analyzing logs with jq
+
+All examples below assume:
+
+- The JSON log has been stripped with `assets/strip-log-escapes.py`
+- The log path is in `$LOG`:
+
+```bash
+LOG="/path/to/clean.json"
 ```
 
-Node kills, stops, pauses, and throttle all look like this:
+### Filtering events
 
-```json
-{
-    fault:{
-        affected_nodes:[server-3],
-        max_duration:1.7741677258234223,
-        name:kill,
-        type:node
-    }
-}
+Filter by source name:
+
+```bash
+jq '[.[] | select(.source.name == "fault_injector")]' "$LOG"
 ```
 
-System level clock skew moves the time forward/backward by the `offset` and then applies the offset in the other direction to return the time to normal.
+Filter by stream (application stderr only):
 
-```json
-{
-    fault:{
-        affected_nodes:[ALL],
-        details:{
-            offset:-0.11456344671067203
-        },
-        max_duration:0.15177661326674713,
-        name:skip,
-        type:clock
-    }
-}
+```bash
+jq '[.[] | select(.source.stream == "error")]' "$LOG"
 ```
 
-#### Fault types and what they mean
+Filter fault events by fault name:
 
-- **Network Partition**: Containers are placed in partition groups; if there is a link between containers in different groups that link will experience the `disruption_type`. Links between containers in the same group are not faulted by this event, but can be faulted by an overlapping event.
-- **Network Clog**: The links of containers listed in `affected_nodes` will be subject to the `disruption_type` at random times for random durations.
+```bash
+jq '[.[] | select(.fault.name == "partition")]' "$LOG"
+```
 
-- Explanation of `disruption_type`'s:
-  - Stopped - packets are dropped entirely
-  - Slowed - packets are delayed with latency
-  - Jammed - packets are "piled up" until a future deliver time
+Filter by fault type:
 
-- **Container Kill / Stop / Pause**: The named container is killed, stopped, or paused for some duration. If it is killed or stopped Antithesis will restart the container after the duration. If a restart policy is defined the container may be restarted immediately by docker-compose.
-- **CPU Throttle**: The cpu on the target container is slowed for a duration.
-- **Clock Skew**: System clock on the host system which runs the containers is jumped forward or backward.
+```bash
+jq '[.[] | select(.fault.type == "network")]' "$LOG"
+```
 
-### How to interpret causality
+Search output_text for a keyword (case-insensitive):
 
-When prompted to determine the cause of an error (e.g., container exit, assertion failure, error log message)
-which appears AFTER an Antithesis fault event:
+```bash
+jq '[.[] | select(.output_text != null and (.output_text | test("error"; "i")))]' "$LOG"
+```
 
-1. Check if the fault targeted the container involved in the error
-2. If yes, some errors are expected — the real question
-   is whether the test code or customer code correctly handled the error
-3. If no fault preceded the error, the failure may not have been caused by the fault event
+Container lifecycle events:
 
-For a more structured approach, use the fault windows methodology below.
+```bash
+jq '[.[] | select(.event == "die")]' "$LOG"
+```
 
-#### Thinking in fault windows
+Combine filters — fault partitions affecting a specific container:
+
+```bash
+jq '[.[] | select(.fault.name == "partition" and (.fault.affected_nodes | index("mycontainer") or index("ALL")))]' "$LOG"
+```
+
+### Filtering by virtual time
+
+Filter by tick range directly (most efficient):
+
+```bash
+jq '[.[] | select(.moment._vtime_ticks >= 400000000000 and .moment._vtime_ticks <= 500000000000)]' "$LOG"
+```
+
+To convert a vtime in seconds to ticks for use in filters, multiply by
+`4294967296`. For example, to filter between 100s and 110s:
+
+```bash
+jq --argjson lo 429496729600 --argjson hi 472446402560 \
+  '[.[] | select(.moment._vtime_ticks >= $lo and .moment._vtime_ticks <= $hi)]' "$LOG"
+```
+
+Compute the bounds with: `seconds * 4294967296`. For example:
+
+- 100s → `100 * 4294967296 = 429496729600`
+- 110s → `110 * 4294967296 = 472446402560`
+
+Add a vtime_seconds field to output for readability:
+
+```bash
+jq '[.[] | . + {vtime_seconds: ((.moment._vtime_ticks | tonumber) / 4294967296 * 1000 | round / 1000)}]' "$LOG"
+```
+
+## Interpreting logs
+
+### Two sources of log lines
+
+Antithesis logs interleave two sources:
+
+1. **Antithesis system events** — fault injection, container lifecycle,
+   network changes, compose orchestration. Identified by source names like
+   `fault_injector`, `containers_meta`, `setup`, `antithesis_test_composer`.
+2. **Application logs** — from the SUT containers. Identified by having
+   `output_text` and a `source.container` field matching a Docker container
+   name.
+
+### Fault types and what they mean
+
+- **Network Partition** (`partition`/`network`): Containers are split into
+  partition groups. Links between different groups experience the
+  `disruption_type`. Links within the same group are unaffected by this event
+  but may be faulted by an overlapping one.
+- **Network Clog** (`clog`/`network`): Links of containers in `affected_nodes`
+  experience the `disruption_type` at random times for random durations.
+- **Network Restore** (`restore`/`network`): Restores all faulted network
+  links.
+- `disruption_type` values: `Stopped` (packets dropped), `Slowed` (packets
+  delayed), `Jammed` (packets queued until a future delivery time).
+- **Container Kill / Stop / Pause** (`kill`|`stop`|`pause`/`node`): The named
+  container is killed, stopped, or paused for `max_duration` seconds. Killed
+  or stopped containers are restarted by Antithesis after the duration. A
+  restart policy in docker-compose may restart it sooner.
+- **CPU Throttle** (`throttle`/`node`): CPU on the target container is slowed
+  for a duration.
+- **Clock Skew** (`skip`/`clock`): System clock is jumped forward or backward
+  by `details.offset` seconds, then reversed after `max_duration`.
+
+### Correlating faults with failures
+
+To determine what faults were active when an assertion failed:
+
+1. Find fault events near the failure timestamp (adjust tick bounds to
+   a window around the failure):
+   ```bash
+   jq --argjson lo 2100000000000 --argjson hi 2200000000000 \
+     '[.[] | select(.fault != null and .moment._vtime_ticks >= $lo and .moment._vtime_ticks <= $hi)]' "$LOG"
+   ```
+2. Check whether `fault.affected_nodes` includes the container involved in the
+   failure (or `"ALL"`)
+3. Compare `fault.max_duration` with the time gap between the fault and the
+   assertion to determine if the fault was still active
+
+### Thinking in fault windows
 
 1. **Identify fault windows.** Each `partition` or `clog` event opens a window.
-   The window closes at the next `restore` event. A subsequent fault of the same
-   type replaces the network topology rather than restoring it — treat it as
-   opening a new window with a potentially different set of affected containers.
-   If the log ends without a restore, the window extends to the end of the
-   visible timeline. Node faults (`kill`, `stop`, `pause`) and clock faults
-   (`skip`) are point-in-time — their impact lingers until the affected
-   container restarts or the clock corrects.
+   The window closes at the next `restore` event. A subsequent fault of the
+   same type replaces the network topology — treat it as a new window. If the
+   log ends without a restore, the window extends to the end. Node faults
+   (`kill`, `stop`, `pause`) and clock faults (`skip`) are point-in-time —
+   their impact lingers until the container restarts or the clock corrects.
 
 2. **Map affected containers.** Each fault window affects specific containers
-   (listed in `affected_nodes`, or the groups listed in `partitions`).
-   `affected_nodes: [ALL]` means every container is affected.
+   (listed in `affected_nodes`, or the groups in `details.partitions`).
+   `["ALL"]` means every container.
 
 3. **Classify errors relative to windows:**
-   - **Error during fault window, on an affected container** — the fault may
-     have caused the error. The triage question is whether the SUT handled it
-     correctly (e.g., a connection timeout during a partition is expected; data
-     corruption after the partition lifts is a real bug).
-   - **Error shortly after a fault window ends** — recovery-time failures.
-     Check whether the SUT recovered correctly once the fault was lifted.
-   - **Error outside any fault window, or on an unaffected container** — the
-     fault may be unrelated to the error.
-   - **Error before a fault** — the fault did not cause the error.
+   - **During fault window, on affected container** — the fault likely caused
+     the error. Question: did the SUT handle it correctly?
+   - **Shortly after window ends** — recovery-time failure. Did the SUT
+     recover correctly?
+   - **Outside any fault window, or on unaffected container** — fault is
+     likely unrelated.
+   - **Before a fault** — the fault did not cause the error.
 
 4. **Watch for overlapping windows.** Antithesis can inject multiple faults
-   concurrently (e.g., a network partition overlapping with a node kill). When
-   windows overlap, consider whether either fault alone would explain the
-   failure.
+   concurrently (e.g., a partition overlapping with a node kill).
 
-### Key timestamps
+### Virtual time vs application timestamps
 
-Antithesis log timestamps reflect true execution order on the
-host system that runs the containers. When
-correlating Antithesis events with customer container logs, use
-Antithesis timestamps as the source of truth for ordering.
+Antithesis tags each event with it's virtual time, which represents an unambiguous global order of events in the simulation. Antithesis can do this since it runs the system deterministically.
+
+Use virtual time as the source of truth for ordering logs rather than timestamps embedded in application logs. Timestamps printed by the application can be out of order due to faults like clock skew and thread pausing.


### PR DESCRIPTION
## Summary

Improve log handling across setup and triage skills: strip ANSI escape codes from downloaded logs, enforce `NO_COLOR=1` in all containers, and overhaul the triage log reference to document the JSON event format with structured analysis recipes.

## Changes

### ANSI escape stripping for JSON logs

- New `antithesis-triage/assets/strip-log-escapes.py` script that strips ANSI escape codes from `output_text` fields in downloaded JSON logs, leaving all other event data intact
- Built-in unit tests (`--test` flag) covering SGR, CSI, OSC, two-byte escapes, and safe passthrough of JSON/struct payloads
- CI step added to run tests on PRs

### Enforce NO_COLOR=1 in container setup

- `antithesis-setup/SKILL.md`: New rule requiring `NO_COLOR=1` on all services, with self-review checklist item
- `antithesis-setup/references/docker-images.md`: New "Disable Color Output" section explaining why and how
- `antithesis-setup/assets/antithesis/config/docker-compose.yaml`: Template and noop service updated with `NO_COLOR=1` environment

### Overhaul triage log reference

Major rewrite of `antithesis-triage/references/logs.md`:
- Default log downloads to JSON format
- Added post-download strip step using `strip-log-escapes.py`
- Documented JSON event schema (`source`, `moment`, `output_text`, `fault`, etc.)
- Documented virtual time (`_vtime_ticks`) and conversion to seconds
- Added event type identification table
- Added `jq` filtering recipes: by source, stream, fault type, keyword search, virtual time range, container lifecycle, and combined filters
- Restructured fault documentation around JSON fields with clearer descriptions
- Added "Virtual time vs application timestamps" section

### Properties over Findings for failing property navigation

Updated the "Investigate a failing property" workflow in `antithesis-triage/SKILL.md` to direct agents to the Properties section (filtered to Failed) rather than scanning Findings.