### PR TITLE
Add rolling, date-based changelog with label automation

### DIFF
--- a/.ci-scripts/changelog.py
+++ b/.ci-scripts/changelog.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Manage CHANGELOG.md for a rolling, date-based changelog.
+
+Subcommands:
+  add-entry    Add an entry under today's UTC date section.
+  validate     Check that CHANGELOG.md is well-formed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CHANGELOG = REPO_ROOT / "CHANGELOG.md"
+
+DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+CATEGORIES = ("### Breaking Changes", "### Non-breaking Changes")
+
+SECTION_MAP = {
+    "breaking": CATEGORIES[0],
+    "non-breaking": CATEGORIES[1],
+}
+
+EXPECTED_HEADER_FRAGMENT = "# Change Log"
+
+
+def _read_changelog() -> str:
+    if not CHANGELOG.exists():
+        print(f"ERROR: {CHANGELOG} not found", file=sys.stderr)
+        sys.exit(1)
+    return CHANGELOG.read_text(encoding="utf-8")
+
+
+def _write_changelog(content: str) -> None:
+    CHANGELOG.write_text(content, encoding="utf-8")
+
+
+def _split_sections(content: str) -> tuple[str, list[tuple[str, str]]]:
+    """Split changelog into header and a list of (heading_line, body) pairs."""
+    lines = content.split("\n")
+    header_lines: list[str] = []
+    sections: list[tuple[str, str]] = []
+    current_heading: str | None = None
+    current_body_lines: list[str] = []
+
+    for line in lines:
+        if line.startswith("## "):
+            if current_heading is not None:
+                sections.append((current_heading, "\n".join(current_body_lines)))
+            else:
+                header_lines = current_body_lines
+            current_heading = line
+            current_body_lines = []
+        else:
+            current_body_lines.append(line)
+
+    if current_heading is not None:
+        sections.append((current_heading, "\n".join(current_body_lines)))
+    else:
+        header_lines = current_body_lines
+
+    header = "\n".join(header_lines)
+    return header, sections
+
+
+def _reassemble(header: str, sections: list[tuple[str, str]]) -> str:
+    parts = [header]
+    for heading, body in sections:
+        parts.append(heading)
+        parts.append(body)
+    return "\n".join(parts)
+
+
+def _parse_date_heading(heading: str) -> str | None:
+    """Extract date from a heading like '## 2026-04-08'."""
+    match = re.match(r"^## (\d{4}-\d{2}-\d{2})$", heading)
+    if not match:
+        return None
+    return match.group(1)
+
+
+def _today_utc() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+
+# -- Subcommands -------------------------------------------------------------
+
+
+def cmd_add_entry(section: str, entry: str) -> int:
+    """Add an entry under today's UTC date section."""
+    target = SECTION_MAP.get(section)
+    if target is None:
+        print(f"ERROR: unknown section '{section}'", file=sys.stderr)
+        print(f"Valid sections: {', '.join(SECTION_MAP)}", file=sys.stderr)
+        return 1
+
+    today = _today_utc()
+    today_heading = f"## {today}"
+
+    content = _read_changelog()
+    header, sections = _split_sections(content)
+
+    # If today's section doesn't exist, create it at the top.
+    if not sections or sections[0][0] != today_heading:
+        new_body = f"\n{CATEGORIES[0]}\n\n\n{CATEGORIES[1]}\n"
+        sections.insert(0, (today_heading, new_body))
+
+    _, body = sections[0]
+    body_lines = body.split("\n")
+
+    # Find the target category heading and insert after it + one blank line.
+    insert_idx = None
+    for i, line in enumerate(body_lines):
+        if line == target:
+            insert_idx = i + 2
+            break
+
+    if insert_idx is None:
+        print(
+            f"ERROR: category '{target}' not found in today's section",
+            file=sys.stderr,
+        )
+        return 1
+
+    body_lines.insert(insert_idx, f"- {entry}")
+    sections[0] = (today_heading, "\n".join(body_lines))
+
+    _write_changelog(_reassemble(header, sections))
+    print(f"Added entry to {target} under {today}")
+    return 0
+
+
+def cmd_validate() -> int:
+    """Check that CHANGELOG.md is well-formed."""
+    content = _read_changelog()
+    header, sections = _split_sections(content)
+    errors: list[str] = []
+
+    if EXPECTED_HEADER_FRAGMENT not in header:
+        errors.append("missing expected header ('# Change Log')")
+
+    # An empty changelog (no sections yet) is valid.
+    if not sections:
+        if errors:
+            _report_errors(errors)
+            return 1
+        print("Changelog validation passed.")
+        return 0
+
+    seen_dates: set[str] = set()
+    prev_date: str | None = None
+
+    for heading, body in sections:
+        date_str = _parse_date_heading(heading)
+
+        if date_str is None:
+            errors.append(f"cannot parse date from heading: '{heading}'")
+            continue
+
+        if not DATE_RE.match(date_str):
+            errors.append(f"invalid date format: '{date_str}'")
+
+        if date_str in seen_dates:
+            errors.append(f"duplicate date: {date_str}")
+        seen_dates.add(date_str)
+
+        if prev_date is not None and date_str >= prev_date:
+            errors.append(
+                f"dates out of order: {date_str} should come before {prev_date}"
+            )
+        prev_date = date_str
+
+        for cat in CATEGORIES:
+            if cat not in body:
+                errors.append(f"section {date_str} missing '{cat}'")
+
+    if errors:
+        _report_errors(errors)
+        return 1
+
+    print("Changelog validation passed.")
+    return 0
+
+
+def _report_errors(errors: list[str]) -> None:
+    for error in errors:
+        print(f"ERROR: {error}", file=sys.stderr)
+    print(f"Changelog validation failed: {len(errors)} error(s).", file=sys.stderr)
+
+
+# -- Main --------------------------------------------------------------------
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Manage CHANGELOG.md")
+    sub = parser.add_subparsers(dest="command")
+
+    sub.add_parser("validate", help="Check changelog format")
+
+    add_entry_parser = sub.add_parser(
+        "add-entry", help="Add an entry under today's date section"
+    )
+    add_entry_parser.add_argument(
+        "--section",
+        required=True,
+        choices=list(SECTION_MAP),
+        help="Category section (breaking or non-breaking)",
+    )
+    add_entry_parser.add_argument("entry", help="Entry text (without leading '- ')")
+
+    args = parser.parse_args()
+    if args.command is None:
+        parser.print_help()
+        return 1
+
+    if args.command == "validate":
+        return cmd_validate()
+    elif args.command == "add-entry":
+        return cmd_add_entry(args.section, args.entry)
+
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/ci-scripts-lint.yml
+++ b/.github/workflows/ci-scripts-lint.yml
@@ -1,0 +1,49 @@
+name: CI Scripts
+
+on:
+  pull_request:
+    paths:
+      - ".ci-scripts/**"
+      - "CHANGELOG.md"
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install ruff
+        run: pip install ruff==0.11.6
+
+      - name: Lint
+        run: ruff check .ci-scripts/
+
+      - name: Check formatting
+        run: ruff format --check .ci-scripts/
+
+  validate-changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Validate changelog format
+        run: python3 .ci-scripts/changelog.py validate

--- a/.github/workflows/pr-merge-changelog.yml
+++ b/.github/workflows/pr-merge-changelog.yml
@@ -1,0 +1,101 @@
+name: PR Merge Changelog
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - CHANGELOG.md
+
+permissions:
+  contents: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find merged PR
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMIT_SHA: ${{ github.sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Retry loop for GitHub API eventual consistency.
+          for attempt in 1 2 3; do
+            PR_JSON=$(gh api "repos/${REPO}/commits/${COMMIT_SHA}/pulls" \
+              --jq '.[0] // empty' 2>/dev/null || echo "")
+            if [ -n "$PR_JSON" ]; then
+              break
+            fi
+            echo "Attempt ${attempt}: no PR found, retrying in 10s..."
+            sleep 10
+          done
+
+          if [ -z "$PR_JSON" ]; then
+            echo "No PR found for commit — skipping"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          NUMBER=$(echo "$PR_JSON" | jq -r '.number')
+          TITLE=$(echo "$PR_JSON" | jq -r '.title')
+          URL=$(echo "$PR_JSON" | jq -r '.html_url')
+
+          BREAKING=$(echo "$PR_JSON" | jq -r \
+            '[.labels[].name] | map(select(. == "changelog - breaking")) | first // empty')
+          NON_BREAKING=$(echo "$PR_JSON" | jq -r \
+            '[.labels[].name] | map(select(. == "changelog - non-breaking")) | first // empty')
+
+          echo "number=$NUMBER" >> "$GITHUB_OUTPUT"
+          echo "title=$TITLE" >> "$GITHUB_OUTPUT"
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+          echo "breaking=$BREAKING" >> "$GITHUB_OUTPUT"
+          echo "non_breaking=$NON_BREAKING" >> "$GITHUB_OUTPUT"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Check out main
+        if: steps.pr.outputs.skip != 'true' && (steps.pr.outputs.breaking != '' || steps.pr.outputs.non_breaking != '')
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        if: steps.pr.outputs.skip != 'true' && (steps.pr.outputs.breaking != '' || steps.pr.outputs.non_breaking != '')
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Add changelog entry (breaking)
+        if: steps.pr.outputs.breaking != ''
+        env:
+          TITLE: ${{ steps.pr.outputs.title }}
+          NUMBER: ${{ steps.pr.outputs.number }}
+          URL: ${{ steps.pr.outputs.url }}
+        run: |
+          ENTRY="${TITLE} ([PR #${NUMBER}](${URL}))"
+          python3 .ci-scripts/changelog.py add-entry --section breaking "$ENTRY"
+
+      - name: Add changelog entry (non-breaking)
+        if: steps.pr.outputs.non_breaking != ''
+        env:
+          TITLE: ${{ steps.pr.outputs.title }}
+          NUMBER: ${{ steps.pr.outputs.number }}
+          URL: ${{ steps.pr.outputs.url }}
+        run: |
+          ENTRY="${TITLE} ([PR #${NUMBER}](${URL}))"
+          python3 .ci-scripts/changelog.py add-entry --section non-breaking "$ENTRY"
+
+      - name: Commit and push
+        if: steps.pr.outputs.skip != 'true' && (steps.pr.outputs.breaking != '' || steps.pr.outputs.non_breaking != '')
+        env:
+          NUMBER: ${{ steps.pr.outputs.number }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+            exit 0
+          fi
+          git commit -m "Update changelog for PR #${NUMBER}"
+          git pull --rebase origin main
+          git push origin main

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ https://agentskills.io/specification.md
 ## Build, Test, and Development Commands
 
 - `make validate`: validates all SKILLS align with the specification.
+- `make validate-changelog`: validates CHANGELOG.md format.
 
 ## Coding Style & Naming Conventions
 
@@ -43,3 +44,8 @@ PRs should include:
 - What changed and why.
 - Validation evidence (`make validate` output).
 - Any follow-up work or limitations.
+
+For notable changes (new skills, breaking changes, significant fixes), add a
+`changelog - breaking` or `changelog - non-breaking` label to the PR. A bot
+updates `CHANGELOG.md` automatically on merge using the PR title. Do not edit
+`CHANGELOG.md` directly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Change Log
+
+All notable changes to this project will be documented in this file. Entries
+are grouped by date (UTC) with newest first.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,3 +21,27 @@ make validate-links
 ```
 
 This uses `lychee` to check repository links, including raw URLs inside Markdown code spans via `--include-verbatim`.
+
+## Changelog
+
+Changelog entries are managed automatically via PR labels. Do not edit
+`CHANGELOG.md` directly.
+
+Add one of these labels to PRs with notable changes:
+
+- `changelog - breaking` — changes existing behavior in a way that requires
+  users to adapt.
+- `changelog - non-breaking` — new features, fixes, and other improvements.
+
+Not every PR needs a label. Internal CI changes, typo fixes, and similar
+housekeeping generally don't.
+
+When a labeled PR is merged, a bot adds the PR title to `CHANGELOG.md` under
+the matching category, grouped by date (UTC). Write your PR title as a
+changelog entry.
+
+## Validate changelog
+
+```bash
+make validate-changelog
+```

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
-.PHONY: validate validate-links install-dev test
+.PHONY: validate validate-changelog validate-links install-dev test
 
 validate:
 	uv run python scripts/validate-skills.py
+
+validate-changelog:
+	python3 .ci-scripts/changelog.py validate
 
 test:
 	uv run python antithesis-triage/assets/process-logs.py --test


### PR DESCRIPTION
When a PR with a `changelog - breaking` or `changelog - non-breaking` label is merged, a workflow adds the PR title to CHANGELOG.md under the matching category, grouped by UTC date. No versioning, no releases — just a running record of notable changes.

- `.ci-scripts/changelog.py` with `add-entry` and `validate` subcommands
- `pr-merge-changelog` workflow triggered on push to main
- `ci-scripts-lint` workflow to lint `.ci-scripts/` and validate changelog on PRs
- Makefile, AGENTS.md, and CONTRIBUTING.md updated

Closes #103