### PR TITLE
Add existing-assertions.md to scratchbook reference docs

### DIFF
--- a/antithesis-research/references/scratchbook-artifacts.md
+++ b/antithesis-research/references/scratchbook-artifacts.md
@@ -9,6 +9,7 @@ The scratchbook lives at `antithesis/scratchbook/` in the target repository and 
 | Artifact | Producer | Consumers | Purpose |
 |---|---|---|---|
 | `sut-analysis.md` | research | setup, workload | System architecture, components, data flows, failure-prone areas |
+| `existing-assertions.md` | research | discovery, evaluation | Scan of existing Antithesis SDK assertions in the codebase |
 | `deployment-topology.md` | research | setup | Minimal container topology for the Antithesis environment |
 | `property-catalog.md` | research | workload, refinement (future) | Concise, scannable catalog of testable properties with priorities |
 | `property-relationships.md` | research | refinement (future) | Suspected clusters and connections between properties |
@@ -21,6 +22,7 @@ The scratchbook lives at `antithesis/scratchbook/` in the target repository and 
 ```
 antithesis/scratchbook/
   sut-analysis.md
+  existing-assertions.md
   deployment-topology.md
   property-catalog.md
   property-relationships.md

--- a/antithesis-research/references/scratchbook-setup.md
+++ b/antithesis-research/references/scratchbook-setup.md
@@ -21,6 +21,7 @@ The Antithesis scratchbook is the central location for durable Antithesis handof
 All research outputs should be written as markdown files in the Antithesis scratchbook. Use the following naming conventions:
 
 - `antithesis/scratchbook/sut-analysis.md` — System architecture, components, data flows, and attack surfaces
+- `antithesis/scratchbook/existing-assertions.md` — Scan of existing Antithesis SDK assertions in the codebase
 - `antithesis/scratchbook/property-catalog.md` — Catalog of testable properties with priorities and scoring
 - `antithesis/scratchbook/deployment-topology.md` — Container topology plan for the Antithesis environment
 - `antithesis/scratchbook/property-relationships.md` — Suspected clusters and connections between properties


### PR DESCRIPTION
`existing-assertions.md` is created in step 4 of the full research pass (SKILL.md) and referenced as a prerequisite by `property-discovery.md` and `property-evaluation.md`, but was missing from the scratchbook reference docs.

Added it to:
- The artifact table and directory layout in `scratchbook-artifacts.md`
- The naming conventions list in `scratchbook-setup.md`

Placed after `sut-analysis.md` to match the workflow order (step 3 → step 4).

Closes #96