### PR TITLE
Triage skill: make the skill more reliable by consolidating dom mutation

### DIFF
--- a/.claude/skills/test-triage/SKILL.md
+++ b/.claude/skills/test-triage/SKILL.md
@@ -97,7 +97,8 @@ actual triage URL and `{{TRIAGE_SKILL}}` with the absolute path to
 Read the skill file at {{TRIAGE_SKILL}} and follow its instructions to triage
 the Antithesis report at {{TRIAGE_URL}}. Investigate the logs of failing
 property most likely to be a SUT bug. Pick any failing property if you aren't
-sure.
+sure. Do NOT explore or analyze any local source code repositories — only use
+the report and downloaded logs to perform your triage.
 ```
 
 ### Phase 3b: Incomplete or no-findings run
@@ -114,6 +115,21 @@ the Antithesis run at {{TARGET_URL}}.
 Wait for both sub-agents to complete.
 
 ## Phase 4: Review and Report
+
+### Understanding the skill protocol
+
+Before auditing the sub-agent traces, read the triage skill and its references
+so you can distinguish correct behavior from violations:
+
+1. Read `antithesis-triage/SKILL.md` — the main skill protocol
+2. Read `antithesis-triage/references/error-reports.md` — the error-report
+   workflow (setup errors, runtime errors, how to download inline logs)
+3. Read `antithesis-triage/references/logs.md` — log analysis guidance
+4. Read `antithesis-triage/references/properties.md` — property triage workflow
+
+Use these as the ground truth when evaluating compliance. If a sub-agent does
+something that looks unusual, check whether the skill documents it before
+flagging it as an issue.
 
 ### Reading sub-agent session traces
 

--- a/antithesis-query-logs-test/audit.js
+++ b/antithesis-query-logs-test/audit.js
@@ -350,20 +350,24 @@
     );
 
     report.checks.push(
-      await runCheck("setup.getFailedProperties", function () {
-        return triage.report.getFailedProperties();
+      await runCheck("setup.getAllProperties", function () {
+        return triage.report.getAllProperties();
       }, function (r) {
-        var props = r.properties || [];
+        var failed = (r.properties || []).filter(function (p) {
+          return p.status === "failed";
+        });
         return {
-          count: props.length,
-          firstName: props.length > 0 ? props[0].name : null,
+          count: failed.length,
+          firstName: failed.length > 0 ? failed[0].name : null,
         };
       }, { keepResult: true }),
     );
 
-    var failedCheck = findCheck(report.checks, "setup.getFailedProperties");
-    var failedProps = failedCheck && failedCheck.result
-      ? failedCheck.result.properties || []
+    var allCheck = findCheck(report.checks, "setup.getAllProperties");
+    var failedProps = allCheck && allCheck.result
+      ? (allCheck.result.properties || []).filter(function (p) {
+          return p.status === "failed";
+        })
       : [];
 
     if (failedProps.length === 0) {

--- a/antithesis-triage/SKILL.md
+++ b/antithesis-triage/SKILL.md
@@ -160,7 +160,7 @@ Make sure NOT to filter by text or status unless explicitly asked. If you are tr
 
 ### Investigate failed properties
 
-1. Read `references/properties.md` - use `getFailedPropertyExamples` to extract failed properties along with their examples and learn how to download logs
+1. Read `references/properties.md` - use `getPropertyExamples()` to extract properties with their examples and learn how to download logs
 2. Read `references/logs.md` to learn how to understand logs
 3. For each property to investigate:
    a. Pick the first failing example

--- a/antithesis-triage/assets/antithesis-triage.js
+++ b/antithesis-triage/assets/antithesis-triage.js
@@ -1,5 +1,5 @@
 (function () {
-  var VERSION = "2.0.0";
+  var VERSION = "3.0.0";
 
   function clean(text) {
     return (text || "").replace(/\s+/g, " ").trim();
@@ -303,27 +303,6 @@
     return match ? Number(match[1]) : null;
   }
 
-  function isSelected(tab) {
-    return !!tab && tab.getAttribute("selected") === "true";
-  }
-
-  async function activateTab(findTab, visibleReady) {
-    var tab = findTab();
-    if (!tab) return null;
-
-    for (var attempt = 0; attempt < 12; attempt++) {
-      click(tab);
-      await wait(250);
-
-      var expected = countFromTab(tab);
-      if (isSelected(tab) && (visibleReady(expected) || expected === 0)) {
-        return tab;
-      }
-    }
-
-    return tab;
-  }
-
   async function waitForReady(checkFn, detailsFn, options) {
     var timeoutMs =
       options && typeof options.timeoutMs === "number"
@@ -359,6 +338,20 @@
     });
   }
 
+  async function expandAllFindings() {
+    var sections = Array.from(
+      document.querySelectorAll("details.findings_section_details"),
+    );
+    var opened = 0;
+    sections.forEach(function (section) {
+      if (!section.open) {
+        section.open = true;
+        opened++;
+      }
+    });
+    if (opened > 0) await wait(300);
+  }
+
   async function expandAllSections() {
     var settleMs = 300;
     var maxPasses = 10;
@@ -389,43 +382,21 @@
   async function expandAllProperties() {
     requireReportPage();
 
-    await activateTab(
-      function () {
-        return tabByPattern(/\ball\b/);
-      },
-      function () {
-        return visiblePropertyContainers().length > 0;
-      },
-    );
-
-    for (var i = 0; i < 24; i++) {
-      var before = visibleLeafProperties().length;
-      await expandVisibleContainers(
-        function (container) {
-          return !!expanderButton(container) && !isExpanded(container);
-        },
-        1,
-        250,
-      );
-      var after = visibleLeafProperties().length;
-      if (after === before) break;
-    }
-  }
-
-  async function expandVisibleContainers(shouldExpand, maxPasses, settleMs) {
-    for (var i = 0; i < maxPasses; i++) {
+    // Expand all property containers in up to 32 passes (groups and leaves).
+    for (var i = 0; i < 32; i++) {
       var changed = false;
 
-      visiblePropertyContainers().forEach(function (container) {
-        if (!shouldExpand(container)) return;
-
-        if (click(expanderButton(container))) {
-          changed = true;
-        }
-      });
+      document
+        .querySelectorAll(".property__expander-button")
+        .forEach(function (btn) {
+          var container = btn.closest(".property-container");
+          if (!container || !isVisible(container) || isExpanded(container))
+            return;
+          if (click(btn)) changed = true;
+        });
 
       if (!changed) break;
-      await wait(settleMs);
+      await wait(250);
     }
   }
 
@@ -438,9 +409,9 @@
     return { passingCount: match[1], failingCount: match[2] };
   }
 
-  // Assumes leaf properties are already expanded by the caller (getAllProperties
-  // and getFilteredProperties both expand all containers before calling this).
-  // Pass/fail example counts are only present in the DOM after expansion.
+  // Assumes leaf properties are already expanded (waitForReady expands all
+  // sections and properties on load). Pass/fail example counts are only
+  // present in the DOM after expansion.
   function visibleLeafProperties(filterStatus) {
     return visiblePropertyContainers()
       .filter(function (container) {
@@ -724,10 +695,8 @@
     );
   }
 
-  async function getAllProperties() {
+  function getAllProperties() {
     requireReportPage();
-
-    await expandAllProperties();
 
     var tab = tabByPattern(/\ball\b/);
     var properties = visibleLeafProperties();
@@ -737,132 +706,9 @@
     }, {});
 
     return {
-      filter: "all",
       expectedCount: countFromTab(tab),
       counts: counts,
       properties: properties,
-    };
-  }
-
-  async function getFilteredProperties(target) {
-    requireReportPage();
-
-    var tab = await activateTab(
-      function () {
-        if (target === "failed") {
-          return (
-            document.querySelector("a-tab._failing") ||
-            tabByPattern(/\bfailed\b/)
-          );
-        }
-        if (target === "passed") {
-          return (
-            document.querySelector("a-tab._passing") ||
-            tabByPattern(/\bpassed\b/)
-          );
-        }
-        return tabByPattern(/\ball\b/);
-      },
-      function () {
-        return visiblePropertyContainers().some(function (container) {
-          return !target || containerStatus(container) === target;
-        });
-      },
-    );
-
-    await expandVisibleContainers(
-      function (container) {
-        if (!expanderButton(container) || isExpanded(container)) return false;
-        // The passed tab already filters the tree; only expand passed-status branches there.
-        if (target === "passed") return containerStatus(container) === target;
-        return true;
-      },
-      target === "passed" ? 16 : 24,
-      target === "passed" ? 300 : 250,
-    );
-
-    return {
-      filter: target || "all",
-      expectedCount: countFromTab(tab),
-      properties: visibleLeafProperties(target),
-    };
-  }
-
-  function expandedPropertiesWithExamples(statuses) {
-    return visiblePropertyContainers()
-      .filter(function (container) {
-        return (
-          !isGroup(container) &&
-          statuses.indexOf(containerStatus(container)) >= 0 &&
-          examplesRows(container) > 0
-        );
-      })
-      .map(function (container) {
-        return {
-          group: groupPath(container),
-          name: nameOf(container),
-          status: containerStatus(container),
-          exampleRows: examplesRows(container),
-        };
-      })
-      .filter(function (property) {
-        return property.name;
-      });
-  }
-
-  async function expandExamplesForStatuses(targetStatuses) {
-    requireReportPage();
-
-    var statuses =
-      Array.isArray(targetStatuses) && targetStatuses.length
-        ? targetStatuses.slice()
-        : ["failed", "passed"];
-    var expandedProperties = [];
-
-    for (var si = 0; si < statuses.length; si++) {
-      var status = statuses[si];
-      if (status !== "failed" && status !== "passed" && status !== "unfound") {
-        continue;
-      }
-
-      await getFilteredProperties(status);
-
-      for (var i = 0; i < 8; i++) {
-        var changed = false;
-
-        visiblePropertyContainers().forEach(function (container) {
-          if (!isVisible(container) || isGroup(container)) return;
-          if (
-            containerStatus(container) !== status ||
-            examplesRows(container) > 0
-          ) {
-            return;
-          }
-
-          var button = expanderButton(container);
-          if (button && click(button)) {
-            changed = true;
-          }
-        });
-
-        if (changed) {
-          await wait(250);
-        } else {
-          break;
-        }
-      }
-
-      expandedProperties = expandedProperties.concat(
-        expandedPropertiesWithExamples([status]),
-      );
-    }
-
-    return {
-      filter: statuses.join(","),
-      expandedProperties: expandedProperties,
-      totalExampleRows: expandedProperties.reduce(function (sum, property) {
-        return sum + property.exampleRows;
-      }, 0),
     };
   }
 
@@ -924,53 +770,32 @@
     };
   }
 
-  async function getPropertyExamples(targetStatuses) {
+  function getPropertyExamples() {
     requireReportPage();
 
-    var statuses =
-      Array.isArray(targetStatuses) && targetStatuses.length
-        ? targetStatuses.slice()
-        : ["failed", "passed"];
-    var properties = [];
-
-    for (var si = 0; si < statuses.length; si++) {
-      var status = statuses[si];
-      await expandExamplesForStatuses([status]);
-
-      properties = properties.concat(
-        visiblePropertyContainers()
-          .filter(function (container) {
-            return (
-              !isGroup(container) &&
-              containerStatus(container) === status &&
-              examplesRows(container) > 0
-            );
-          })
-          .map(function (container) {
-            return {
-              group: groupPath(container),
-              name: nameOf(container),
-              status: containerStatus(container),
-              examples: examplesForContainer(container),
-            };
-          })
-          .filter(function (property) {
-            return property.name;
-          }),
-      );
-    }
+    var properties = visiblePropertyContainers()
+      .filter(function (container) {
+        return (
+          !isGroup(container) &&
+          nameOf(container) &&
+          examplesRows(container) > 0
+        );
+      })
+      .map(function (container) {
+        return {
+          group: groupPath(container),
+          name: nameOf(container),
+          status: containerStatus(container),
+          examples: examplesForContainer(container),
+        };
+      });
 
     return {
-      filter: statuses.join(","),
       properties: properties,
       totalExamples: properties.reduce(function (sum, property) {
         return sum + property.examples.length;
       }, 0),
     };
-  }
-
-  async function getFailedPropertyExamples() {
-    return getPropertyExamples(["failed"]);
   }
 
   var reportApi = {
@@ -1109,7 +934,8 @@
 
       function status(loaded, section) {
         if (loaded) return "ok";
-        if (err && section && hasLoadingText(section.textContent)) return "error";
+        if (err && section && hasLoadingText(section.textContent))
+          return "error";
         if (err) return "error";
         return "not_loaded";
       }
@@ -1164,6 +990,7 @@
 
       await expandAllSections();
       if (sectionStatus.properties === "ok") await expandAllProperties();
+      if (sectionStatus.findings === "ok") await expandAllFindings();
       return result;
     },
 
@@ -1237,10 +1064,11 @@
         /^Conducted on\s+(.+?)(?:\s*Source:\s*(.+))?$/,
       );
 
-      var metricKeys = { "Test hours": "test_hours", "Wall clock": "wall_clock" };
-      var metrics = document.querySelectorAll(
-        ".utilization-summary__metric",
-      );
+      var metricKeys = {
+        "Test hours": "test_hours",
+        "Wall clock": "wall_clock",
+      };
+      var metrics = document.querySelectorAll(".utilization-summary__metric");
       var utilization = {};
       metrics.forEach(function (m) {
         var parts = clean(m.textContent).split(":");
@@ -1277,23 +1105,9 @@
       });
     },
 
-    getFindingsGrouped: async function () {
+    getFindingsGrouped: function () {
       requireReportPage();
 
-      // Expand all findings sections so lazy-rendered content is available.
-      var sections = Array.from(
-        document.querySelectorAll("details.findings_section_details"),
-      );
-      var opened = 0;
-      sections.forEach(function (section) {
-        if (!section.open) {
-          section.open = true;
-          opened++;
-        }
-      });
-      if (opened > 0) await wait(300);
-
-      // Re-query after expansion in case the DOM changed.
       return Array.from(
         document.querySelectorAll("details.findings_section_details"),
       )
@@ -1333,18 +1147,8 @@
     },
 
     getAllProperties: getAllProperties,
-    getFailedProperties: function () {
-      return getFilteredProperties("failed");
-    },
-    getPassedProperties: function () {
-      return getFilteredProperties("passed");
-    },
-    getUnfoundProperties: function () {
-      return getFilteredProperties("unfound");
-    },
     getExampleLogsUrl: getExampleLogsUrl,
     getPropertyExamples: getPropertyExamples,
-    getFailedPropertyExamples: getFailedPropertyExamples,
   };
 
   var logsApi = {

--- a/antithesis-triage/references/logs.md
+++ b/antithesis-triage/references/logs.md
@@ -87,9 +87,10 @@ All examples below assume the log path is in `$LOG`:
 LOG="/path/to/clean.json"
 ```
 
-**Null-safe string matching:** Many event fields are optional and may be `null`.
-Use jq's `//` (coalesce) operator before string functions like `test()` or
-`startswith()` to avoid errors: `.output_text // "" | test("pattern")`.
+**Null-safe string matching:** Many event fields are optional and may be `null`,
+including `source.name`. Use jq's `//` (coalesce) operator before string
+functions like `test()` or `startswith()` to avoid errors:
+`.output_text // "" | test("pattern")`, `(.source.name // "") | startswith("node")`.
 
 ### Suggested first-look workflow
 

--- a/antithesis-triage/references/properties.md
+++ b/antithesis-triage/references/properties.md
@@ -2,14 +2,22 @@
 
 `report` refers to `window.__antithesisTriage.report` in this file.
 
-## Primary property queries:
+## Getting all properties
 
-- `report.getAllProperties()` — all properties
-- `report.getFailedProperties()` — failed properties only
-- `report.getPassedProperties()` — passed properties only
-- `report.getUnfoundProperties()` — unfound properties only
+`report.getAllProperties()` returns every property in a single JSON object.
+All properties are already expanded by `waitForReady()`, so this is a
+synchronous read of the current DOM state — no tab switching or expansion
+occurs.
 
-Each property in the returned `properties` array includes:
+```json
+{
+  "expectedCount": 42,
+  "counts": { "failed": 3, "passed": 37, "unfound": 2 },
+  "properties": [ ... ]
+}
+```
+
+Each entry in the `properties` array:
 
 ```json
 {
@@ -22,6 +30,33 @@ Each property in the returned `properties` array includes:
 ```
 
 `passingCount` and `failingCount` are comma-formatted count strings representing the total across all execution histories in the run (not just the 3-4 example rows shown in the UI).
+
+### Filtering properties with jq
+
+Use `jq` to filter the output of `getAllProperties()` rather than calling
+separate status-specific methods:
+
+```bash
+# Failed properties only
+agent-browser --session "$SESSION" eval \
+  "window.__antithesisTriage.report.getAllProperties()" \
+  | jq '.properties | map(select(.status == "failed"))'
+
+# Passed properties only
+agent-browser --session "$SESSION" eval \
+  "window.__antithesisTriage.report.getAllProperties()" \
+  | jq '.properties | map(select(.status == "passed"))'
+
+# Unfound properties only
+agent-browser --session "$SESSION" eval \
+  "window.__antithesisTriage.report.getAllProperties()" \
+  | jq '.properties | map(select(.status == "unfound"))'
+
+# Properties in a specific group
+agent-browser --session "$SESSION" eval \
+  "window.__antithesisTriage.report.getAllProperties()" \
+  | jq '.properties | map(select(.group | any(test("SDK: Go"))))'
+```
 
 ### Using pass/fail ratios for triage prioritization
 
@@ -46,11 +81,20 @@ Numeric/boolean variants (e.g., `AlwaysGreaterThan`, `SometimesAll`) follow the 
 
 ## Property examples
 
-- `report.getPropertyExamples()` - all properties with example tables
-- `report.getFailedPropertyExamples()` - failed properties with example tables
+`report.getPropertyExamples()` returns all properties that have example tables,
+along with their example rows. All example tables are already expanded by
+`waitForReady()`, so this is a synchronous read of the DOM. Use jq to filter
+by status.
 
 Returns each property with `group`, `name`, `status`, and `examples` array
 containing `{ index: 0, status: "failing", time: "85.75s" }` entries.
+
+```bash
+# Failed property examples only
+agent-browser --session "$SESSION" eval \
+  "window.__antithesisTriage.report.getPropertyExamples()" \
+  | jq '.properties | map(select(.status == "failed"))'
+```
 
 Each property may expose multiple example rows (typically 3-4), mixing failing
 and passing examples. When triaging, start with the **first failing example**


### PR DESCRIPTION
Remove tab-switching and status-specific query methods (getFailedProperties, getPassedProperties, getUnfoundProperties, getFailedPropertyExamples) in favor of a single getAllProperties call with jq-based filtering. Move all section and property expansion into waitForReady so downstream queries are simple DOM reads.

- Remove `activateTab, isSelected, getFilteredProperties, expandExamplesForStatuses, expandedPropertiesWithExamples` helpers
- Simplify `expandAllProperties` to use direct `.property__expander-button` selector
- Add `expandAllFindings` helper, called during `waitForReady`
- Simplify `getPropertyExamples` to read already-expanded DOM
- Update references/properties.md with jq filtering examples
- Update references/logs.md with `source.name` null-safety guidance
- Fix audit.js to use `getAllProperties` with status filtering
- Add skill protocol reading step to test-triage Phase 4