### PR TITLE
Flatten changelog format: inline BREAKING CHANGE prefix

### DIFF
--- a/.ci-scripts/changelog.py
+++ b/.ci-scripts/changelog.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 """Manage CHANGELOG.md for a rolling, date-based changelog.
 
+Entries are grouped by date (UTC) with newest first. Breaking changes
+are prefixed with "BREAKING CHANGE: " in the entry text.
+
 Subcommands:
   add-entry    Add an entry under today's UTC date section.
   validate     Check that CHANGELOG.md is well-formed.
@@ -18,13 +21,6 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 CHANGELOG = REPO_ROOT / "CHANGELOG.md"
 
 DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
-
-CATEGORIES = ("### Breaking Changes", "### Non-breaking Changes")
-
-SECTION_MAP = {
-    "breaking": CATEGORIES[0],
-    "non-breaking": CATEGORIES[1],
-}
 
 EXPECTED_HEADER_FRAGMENT = "# Change Log"
 
@@ -91,47 +87,31 @@ def _today_utc() -> str:
 # -- Subcommands -------------------------------------------------------------
 
 
-def cmd_add_entry(section: str, entry: str) -> int:
+def cmd_add_entry(entry: str, breaking: bool = False) -> int:
     """Add an entry under today's UTC date section."""
-    target = SECTION_MAP.get(section)
-    if target is None:
-        print(f"ERROR: unknown section '{section}'", file=sys.stderr)
-        print(f"Valid sections: {', '.join(SECTION_MAP)}", file=sys.stderr)
-        return 1
-
     today = _today_utc()
     today_heading = f"## {today}"
+
+    prefix = "BREAKING CHANGE: " if breaking else ""
+    formatted = f"- {prefix}{entry}"
 
     content = _read_changelog()
     header, sections = _split_sections(content)
 
     # If today's section doesn't exist, create it at the top.
     if not sections or sections[0][0] != today_heading:
-        new_body = f"\n{CATEGORIES[0]}\n\n\n{CATEGORIES[1]}\n"
-        sections.insert(0, (today_heading, new_body))
+        sections.insert(0, (today_heading, "\n"))
 
     _, body = sections[0]
     body_lines = body.split("\n")
 
-    # Find the target category heading and insert after it + one blank line.
-    insert_idx = None
-    for i, line in enumerate(body_lines):
-        if line == target:
-            insert_idx = i + 2
-            break
-
-    if insert_idx is None:
-        print(
-            f"ERROR: category '{target}' not found in today's section",
-            file=sys.stderr,
-        )
-        return 1
-
-    body_lines.insert(insert_idx, f"- {entry}")
+    # Insert after the first blank line (right after the date heading).
+    body_lines.insert(1, formatted)
     sections[0] = (today_heading, "\n".join(body_lines))
 
     _write_changelog(_reassemble(header, sections))
-    print(f"Added entry to {target} under {today}")
+    label = "breaking" if breaking else "non-breaking"
+    print(f"Added {label} entry under {today}")
     return 0
 
 
@@ -175,10 +155,6 @@ def cmd_validate() -> int:
             )
         prev_date = date_str
 
-        for cat in CATEGORIES:
-            if cat not in body:
-                errors.append(f"section {date_str} missing '{cat}'")
-
     if errors:
         _report_errors(errors)
         return 1
@@ -206,10 +182,9 @@ def main() -> int:
         "add-entry", help="Add an entry under today's date section"
     )
     add_entry_parser.add_argument(
-        "--section",
-        required=True,
-        choices=list(SECTION_MAP),
-        help="Category section (breaking or non-breaking)",
+        "--breaking",
+        action="store_true",
+        help="Mark entry as a breaking change",
     )
     add_entry_parser.add_argument("entry", help="Entry text (without leading '- ')")
 
@@ -221,7 +196,7 @@ def main() -> int:
     if args.command == "validate":
         return cmd_validate()
     elif args.command == "add-entry":
-        return cmd_add_entry(args.section, args.entry)
+        return cmd_add_entry(args.entry, breaking=args.breaking)
 
     return 1
 

--- a/.github/workflows/pr-merge-changelog.yml
+++ b/.github/workflows/pr-merge-changelog.yml
@@ -42,50 +42,45 @@ jobs:
           TITLE=$(echo "$PR_JSON" | jq -r '.title')
           URL=$(echo "$PR_JSON" | jq -r '.html_url')
 
+          HAS_CHANGELOG=$(echo "$PR_JSON" | jq -r \
+            '[.labels[].name] | map(select(startswith("changelog - "))) | first // empty')
           BREAKING=$(echo "$PR_JSON" | jq -r \
             '[.labels[].name] | map(select(. == "changelog - breaking")) | first // empty')
-          NON_BREAKING=$(echo "$PR_JSON" | jq -r \
-            '[.labels[].name] | map(select(. == "changelog - non-breaking")) | first // empty')
 
           echo "number=$NUMBER" >> "$GITHUB_OUTPUT"
           echo "title=$TITLE" >> "$GITHUB_OUTPUT"
           echo "url=$URL" >> "$GITHUB_OUTPUT"
+          echo "has_changelog=$HAS_CHANGELOG" >> "$GITHUB_OUTPUT"
           echo "breaking=$BREAKING" >> "$GITHUB_OUTPUT"
-          echo "non_breaking=$NON_BREAKING" >> "$GITHUB_OUTPUT"
           echo "skip=false" >> "$GITHUB_OUTPUT"
 
       - name: Check out main
-        if: steps.pr.outputs.skip != 'true' && (steps.pr.outputs.breaking != '' || steps.pr.outputs.non_breaking != '')
+        if: steps.pr.outputs.skip != 'true' && steps.pr.outputs.has_changelog != ''
         uses: actions/checkout@v4
 
       - name: Set up Python
-        if: steps.pr.outputs.skip != 'true' && (steps.pr.outputs.breaking != '' || steps.pr.outputs.non_breaking != '')
+        if: steps.pr.outputs.skip != 'true' && steps.pr.outputs.has_changelog != ''
         uses: actions/setup-python@v5
         with:
           python-version: "3.x"
 
-      - name: Add changelog entry (breaking)
-        if: steps.pr.outputs.breaking != ''
+      - name: Add changelog entry
+        if: steps.pr.outputs.has_changelog != ''
         env:
           TITLE: ${{ steps.pr.outputs.title }}
           NUMBER: ${{ steps.pr.outputs.number }}
           URL: ${{ steps.pr.outputs.url }}
+          BREAKING: ${{ steps.pr.outputs.breaking }}
         run: |
           ENTRY="${TITLE} ([PR #${NUMBER}](${URL}))"
-          python3 .ci-scripts/changelog.py add-entry --section breaking "$ENTRY"
-
-      - name: Add changelog entry (non-breaking)
-        if: steps.pr.outputs.non_breaking != ''
-        env:
-          TITLE: ${{ steps.pr.outputs.title }}
-          NUMBER: ${{ steps.pr.outputs.number }}
-          URL: ${{ steps.pr.outputs.url }}
-        run: |
-          ENTRY="${TITLE} ([PR #${NUMBER}](${URL}))"
-          python3 .ci-scripts/changelog.py add-entry --section non-breaking "$ENTRY"
+          ARGS=""
+          if [ -n "$BREAKING" ]; then
+            ARGS="--breaking"
+          fi
+          python3 .ci-scripts/changelog.py add-entry $ARGS "$ENTRY"
 
       - name: Commit and push
-        if: steps.pr.outputs.skip != 'true' && (steps.pr.outputs.breaking != '' || steps.pr.outputs.non_breaking != '')
+        if: steps.pr.outputs.skip != 'true' && steps.pr.outputs.has_changelog != ''
         env:
           NUMBER: ${{ steps.pr.outputs.number }}
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,5 +47,6 @@ PRs should include:
 
 For notable changes (new skills, breaking changes, significant fixes), add a
 `changelog - breaking` or `changelog - non-breaking` label to the PR. A bot
-updates `CHANGELOG.md` automatically on merge using the PR title. Do not edit
-`CHANGELOG.md` directly.
+updates `CHANGELOG.md` automatically on merge using the PR title — breaking
+entries are prefixed with `BREAKING CHANGE:`. Do not edit `CHANGELOG.md`
+directly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,18 +5,9 @@ are grouped by date (UTC) with newest first.
 
 ## 2026-04-10
 
-### Breaking Changes
-
-
-### Non-breaking Changes
-
 - Updated fault model to track all supported fault windows ([PR #110](https://github.com/antithesishq/antithesis-skills/pull/110))
 - Triage skill: make the skill more reliable by consolidating dom mutation ([PR #111](https://github.com/antithesishq/antithesis-skills/pull/111))
+
 ## 2026-04-09
-
-### Breaking Changes
-
-
-### Non-breaking Changes
 
 - Add fault documentation to research skill ([PR #109](https://github.com/antithesishq/antithesis-skills/pull/109))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,15 +30,17 @@ Changelog entries are managed automatically via PR labels. Do not edit
 Add one of these labels to PRs with notable changes:
 
 - `changelog - breaking` — changes existing behavior in a way that requires
-  users to adapt.
+  users to adapt. The entry will be prefixed with `BREAKING CHANGE:`.
 - `changelog - non-breaking` — new features, fixes, and other improvements.
+
+If a PR has both labels, it gets a single entry with the `BREAKING CHANGE:`
+prefix.
 
 Not every PR needs a label. Internal CI changes, typo fixes, and similar
 housekeeping generally don't.
 
 When a labeled PR is merged, a bot adds the PR title to `CHANGELOG.md` under
-the matching category, grouped by date (UTC). Write your PR title as a
-changelog entry.
+the date (UTC). Write your PR title as a changelog entry.
 
 ## Validate changelog
 


### PR DESCRIPTION
Replace the separate "Breaking Changes" / "Non-breaking Changes" subsections
with a flat list under each date. Breaking entries are prefixed with
`BREAKING CHANGE:` instead of living under their own heading.

- `changelog.py`: `--section breaking|non-breaking` replaced with `--breaking`
  flag. Validator no longer requires category headings.
- `pr-merge-changelog.yml`: Two add-entry steps collapsed into one. Both labels
  on a PR produce a single entry with the prefix.
- Existing CHANGELOG.md entries migrated (all were non-breaking).
- CONTRIBUTING.md and AGENTS.md updated to describe the new format.