### PR TITLE
Setup skill: add mid-workflow re-evaluation prompt between implementation phases

### DIFF
--- a/antithesis-setup/SKILL.md
+++ b/antithesis-setup/SKILL.md
@@ -40,7 +40,7 @@ Use the `antithesis-documentation` skill to access these pages. Prefer `snouty d
 
 ## Workflow
 
-This skill is broken out into multiple steps, each in a different reference file. Read and implement each reference file listed below one at a time to fully set up a project.
+This skill is broken out into multiple steps, each in a different reference file. Read and implement each reference file listed below one at a time to fully set up a project. After implementing each step, check whether what you learned invalidates any decisions from earlier steps. Instrumentation decisions (step 2) are the most common thing that needs revision once you start building images (step 3).
 
 - `references/directory-init.md`: initialize or merge the `antithesis/` directory from `assets/antithesis/`
 - `references/instrumentation.md`: decide how each SUT service is instrumented, how the SDK is installed, how symbols are delivered, and where the bootstrap property lives


### PR DESCRIPTION
The setup skill walks through six phases — directory init, instrumentation, docker images, compose, config, and submit. Each phase builds on the one before it. The instructions said to work through them one at a time, but didn't say to look back. So the agent would make instrumentation decisions, move on to building images, discover the decisions didn't work, and keep going anyway. The mismatch only blew up at the final validation step, after several phases of work that now needed redoing.

One sentence now tells the agent to check whether earlier decisions still hold after each phase, and specifically flags instrumentation as the most common thing that needs revision once image builds start.

Closes #115