### PR TITLE
Add deterministic randomness cross-reference to test command guidance

### DIFF
--- a/antithesis-workload/references/test-commands.md
+++ b/antithesis-workload/references/test-commands.md
@@ -114,6 +114,7 @@ These two command types are similar but serve different purposes:
 - Treat commands as levers for the fuzzer. Diverse commands produce richer system states.
 - Reserve `setup_complete` for a container entrypoint or other long-lived startup process that runs before Antithesis starts executing timeline commands.
 - Driver commands connect to the SUT under active fault injection — handle transient network faults gracefully (see `component-implementation.md` for details).
+- All randomness in test commands must go through the Antithesis SDK's random module for deterministic replay (see `assertions.md` for details).
 - Write commands in the project's language, not Bash, so they can reuse existing clients, helpers, and libraries.
 
 ## Output


### PR DESCRIPTION
The requirement to use the Antithesis SDK's random module for deterministic replay lives in assertions.md but applies equally to test command code. During post-triage iteration (SKILL.md workflow step 2), test-commands.md can be read without assertions.md, so an agent adding a new driver that uses randomness could miss the requirement. Adds a cross-reference in the Guidance section.