### PR TITLE
Backfill skill version metadata

### DIFF
--- a/antithesis-debug/SKILL.md
+++ b/antithesis-debug/SKILL.md
@@ -6,6 +6,8 @@ description: >
   filesystems and runtime state, run shell commands, and extract evidence
   from inside the Antithesis environment. Supports both the simplified
   debugger (default) and the advanced notebook mode.
+metadata:
+  version: "2026-04-14 077d0ea"
 ---
 
 # Antithesis Multiverse Debugger

--- a/antithesis-documentation/SKILL.md
+++ b/antithesis-documentation/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: antithesis-documentation
 description: Use Antithesis documentation efficiently for product, workflow, and integration questions. Prefer the snouty docs CLI when available, and otherwise request markdown versions of documentation pages directly.
+metadata:
+  version: "2026-04-14 077d0ea"
 ---
 
 # Antithesis Documentation

--- a/antithesis-launch/SKILL.md
+++ b/antithesis-launch/SKILL.md
@@ -6,6 +6,8 @@ description: >
   bailing on validation failure, and then submitting `snouty run` with sane
   metadata. Use when the user wants to send, submit, or launch an Antithesis
   run. This skill takes duration in minutes as input.
+metadata:
+  version: "2026-04-14 077d0ea"
 ---
 
 # Antithesis Launch

--- a/antithesis-query-logs/SKILL.md
+++ b/antithesis-query-logs/SKILL.md
@@ -5,6 +5,8 @@ description: >
   correlate property failures, and answer temporal questions about ordering
   and causation (e.g., did event A always precede failure B? do failures
   occur even without a preceding fault?).
+metadata:
+  version: "2026-04-14 077d0ea"
 ---
 
 # Antithesis Logs Explorer

--- a/antithesis-research/SKILL.md
+++ b/antithesis-research/SKILL.md
@@ -4,6 +4,8 @@ description: >
   Analyze a codebase to figure out how it should be tested with Antithesis:
   map the system, identify failure-prone areas and testable properties, and
   produce the research artifacts needed for workload and environment planning.
+metadata:
+  version: "2026-04-14 077d0ea"
 ---
 
 # Antithesis Research

--- a/antithesis-setup/SKILL.md
+++ b/antithesis-setup/SKILL.md
@@ -4,6 +4,8 @@ description: >
   Scaffold the Antithesis harness: initialize the working directory, write
   Dockerfiles and docker-compose.yaml with build directives, and prepare
   to submit your first Antithesis test run.
+metadata:
+  version: "2026-04-14 077d0ea"
 ---
 
 # Antithesis Setup

--- a/antithesis-skills-feedback/SKILL.md
+++ b/antithesis-skills-feedback/SKILL.md
@@ -2,6 +2,8 @@
 name: antithesis-skills-feedback
 description: >
   Send Antithesis feedback or a bug report regarding Antithesis skills for AI agents.
+metadata:
+  version: "2026-04-14 077d0ea"
 ---
 
 # Antithesis Skills feedback

--- a/antithesis-triage/SKILL.md
+++ b/antithesis-triage/SKILL.md
@@ -2,6 +2,8 @@
 name: antithesis-triage
 description: >
   Use this skill to triage Antithesis runs (reports). Use this skill to lookup runs, check run status, triage properties (assertions), view run metadata, download logs, view findings, or inspect environmental details.
+metadata:
+  version: "2026-04-14 077d0ea"
 ---
 
 # Antithesis Report Triage

--- a/antithesis-workload/SKILL.md
+++ b/antithesis-workload/SKILL.md
@@ -3,6 +3,8 @@ name: antithesis-workload
 description: >
   Implement Antithesis workloads by turning the property catalog into SDK
   assertions and test commands, then refine coverage after triage.
+metadata:
+  version: "2026-04-14 077d0ea"
 ---
 
 # Antithesis Workload


### PR DESCRIPTION
The Agent Skills spec supports a `metadata` field in SKILL.md frontmatter
for arbitrary key-value pairs. We're adopting `metadata.version` to track
skill versions as `"DATE SHA"` matching changelog entries.

This backfills all 9 skills with `"2026-04-14 077d0ea"` — the most recent
changelog date and the commit that triggered it.

A follow-up PR will add automation to bump this version whenever the
changelog is updated.