### PR TITLE
Improve descriptions for triage and skills-feedback skills

### DIFF
--- a/antithesis-skills-feedback/SKILL.md
+++ b/antithesis-skills-feedback/SKILL.md
@@ -1,7 +1,11 @@
 ---
 name: antithesis-skills-feedback
 description: >
-  Send Antithesis feedback or a bug report regarding Antithesis skills for AI agents.
+  File a bug report or feedback on the Antithesis skills by opening a
+  pre-filled GitHub issue URL (skill name, skill version, agent, short
+  summary). Load when the user wants to report a problem with, or give
+  feedback on, any Antithesis skill. Does not auto-submit — presents the
+  URL for the user to review.
 metadata:
   version: "2026-04-14 077d0ea"
 ---

--- a/antithesis-triage/SKILL.md
+++ b/antithesis-triage/SKILL.md
@@ -1,7 +1,10 @@
 ---
 name: antithesis-triage
 description: >
-  Use this skill to triage Antithesis runs (reports). Use this skill to lookup runs, check run status, triage properties (assertions), view run metadata, download logs, view findings, or inspect environmental details.
+  Triage Antithesis test reports to understand what happened in a run: look
+  up runs, check status, investigate failed properties (assertions), view
+  metadata, download logs, inspect findings, and examine environmental
+  details. Load after a run completes or when investigating a failure.
 metadata:
   version: "2026-04-14 077d0ea"
 ---


### PR DESCRIPTION
Rewrote the `description` fields for the `antithesis-triage` and `antithesis-skills-feedback` skills. Agents rely on these descriptions to decide which skill to load for a given task, so a description that enumerates features without stating the trigger — or that is too terse to surface the underlying mechanism — makes the skill harder to auto-activate against a relevant user request.

- `antithesis-triage` now opens with the situational purpose (triaging reports to understand what happened in a run) and closes with an explicit trigger ("after a run completes or when investigating a failure"), replacing the previous description that listed features twice and never said when to load the skill.
- `antithesis-skills-feedback` now states what the skill actually does (opens a pre-filled GitHub issue URL, without auto-submitting) and when to load it (when the user wants to report a problem with any Antithesis skill), replacing a one-sentence description that hid both the mechanism and the trigger.

Both new descriptions follow the Agent Skills specification's guidance that the description field should describe what the skill does, when to use it, and include keywords that help agents match relevant tasks.