### PR TITLE
Declare environment requirements in skill frontmatter via compatibility field

### DIFF
--- a/antithesis-debug/SKILL.md
+++ b/antithesis-debug/SKILL.md
@@ -6,6 +6,7 @@ description: >
   filesystems and runtime state, run shell commands, and extract evidence
   from inside the Antithesis environment. Supports both the simplified
   debugger (default) and the advanced notebook mode.
+compatibility: Requires agent-browser (https://github.com/vercel-labs/agent-browser).
 metadata:
   version: "2026-04-17 94e2698"
 ---

--- a/antithesis-documentation/SKILL.md
+++ b/antithesis-documentation/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: antithesis-documentation
 description: Use Antithesis documentation efficiently for product, workflow, and integration questions. Prefer the snouty docs CLI when available, and otherwise request markdown versions of documentation pages directly.
+compatibility: Requires snouty (https://github.com/antithesishq/snouty).
 metadata:
   version: "2026-04-17 94e2698"
 ---

--- a/antithesis-launch/SKILL.md
+++ b/antithesis-launch/SKILL.md
@@ -6,6 +6,7 @@ description: >
   bailing on validation failure, and then submitting `snouty run` with sane
   metadata. Use when the user wants to send, submit, or launch an Antithesis
   run. This skill takes duration in minutes as input.
+compatibility: Requires docker (or podman) with compose and snouty (https://github.com/antithesishq/snouty).
 metadata:
   version: "2026-04-17 94e2698"
 ---

--- a/antithesis-query-logs/SKILL.md
+++ b/antithesis-query-logs/SKILL.md
@@ -5,6 +5,7 @@ description: >
   correlate property failures, and answer temporal questions about ordering
   and causation (e.g., did event A always precede failure B? do failures
   occur even without a preceding fault?).
+compatibility: Requires snouty (https://github.com/antithesishq/snouty) and agent-browser (https://github.com/vercel-labs/agent-browser).
 metadata:
   version: "2026-04-17 94e2698"
 ---

--- a/antithesis-setup/SKILL.md
+++ b/antithesis-setup/SKILL.md
@@ -4,6 +4,7 @@ description: >
   Scaffold the Antithesis harness: initialize the working directory, write
   Dockerfiles and docker-compose.yaml with build directives, and prepare
   to submit your first Antithesis test run.
+compatibility: Requires docker (or podman) with compose and snouty (https://github.com/antithesishq/snouty).
 metadata:
   version: "2026-04-17 94e2698"
 ---

--- a/antithesis-triage/SKILL.md
+++ b/antithesis-triage/SKILL.md
@@ -5,6 +5,7 @@ description: >
   up runs, check status, investigate failed properties (assertions), view
   metadata, download logs, inspect findings, and examine environmental
   details. Load after a run completes or when investigating a failure.
+compatibility: Requires snouty (https://github.com/antithesishq/snouty), agent-browser (https://github.com/vercel-labs/agent-browser), and jq.
 metadata:
   version: "2026-04-17 94e2698"
 ---

--- a/antithesis-workload/SKILL.md
+++ b/antithesis-workload/SKILL.md
@@ -3,6 +3,7 @@ name: antithesis-workload
 description: >
   Implement Antithesis workloads by turning the property catalog into SDK
   assertions and test commands, then refine coverage after triage.
+compatibility: Requires snouty (https://github.com/antithesishq/snouty).
 metadata:
   version: "2026-04-17 94e2698"
 ---


### PR DESCRIPTION
Seven skills now declare their environment requirements using the standard `compatibility` frontmatter field from the [Agent Skills spec](https://agentskills.io/specification#compatibility-field). Clients that inspect skill metadata can surface these requirements to users before loading a skill.

- `antithesis-documentation`, `antithesis-workload`, `antithesis-query-logs` — require snouty
- `antithesis-setup`, `antithesis-launch` — require a container runtime (docker or podman with compose) and snouty
- `antithesis-triage` — requires snouty, agent-browser, and jq
- `antithesis-debug` — requires agent-browser

`antithesis-research` and `antithesis-skills-feedback` have no external-tool requirements, so they are left without a `compatibility` field per the spec's guidance.