### PR TITLE
bring setup et al more inline with Antithesis best practices

### DIFF
--- a/antithesis-setup/SKILL.md
+++ b/antithesis-setup/SKILL.md
@@ -105,7 +105,10 @@ Review criteria:
 
 - `antithesis/config/docker-compose.yaml` exists and every service has `build:` (for local images) or `image:` (for public images) configured correctly
 - Every service in docker-compose.yaml includes `platform: linux/amd64`
-- Every service has `hostname:` set to match its `container_name:`
+- Every service has `hostname:` set to match its `container_name:`, and neither contains an underscore (use hyphens — underscores are not valid DNS label characters)
+- Every service sets `init: true` so the service process does not run as pid 1
+- Cross-service dependencies use `depends_on` with `condition: service_healthy` against a defined `healthcheck`, not plain `depends_on`
+- The runtime compose does NOT set a custom `logging:` driver, does not configure any `internal: true` network, and does not set `pull_policy:`
 - The instrumentation inventory from `references/instrumentation.md` is fully implemented: each service is instrumented, cataloged-only, or explicitly documented as uninstrumented
 - The relevant Antithesis SDK is installed in the SUT dependency graph
 - A bootstrap property exists in a simple, guaranteed-to-run code path (not behind rare behavior)

--- a/antithesis-setup/assets/antithesis/config/docker-compose.yaml
+++ b/antithesis-setup/assets/antithesis/config/docker-compose.yaml
@@ -10,6 +10,8 @@
 # Every service MUST include `platform: linux/amd64` — Antithesis runs on x86-64.
 # Every service MUST set `NO_COLOR=1` — Antithesis stores raw bytes and does
 # not render ANSI escape codes, so color output is garbage.
+# Every service MUST set `init: true`
+# Use healthchecks + `depends_on: condition: service_healthy` to order startup
 #
 # Example:
 #   name: foobar
@@ -38,6 +40,7 @@ services:
   noop:
     platform: linux/amd64
     image: debian:stable-slim
+    init: true
     environment:
       NO_COLOR: "1"
     command: ["sh", "-c", "tail -f /dev/null"]

--- a/antithesis-setup/references/docker-compose.md
+++ b/antithesis-setup/references/docker-compose.md
@@ -18,6 +18,8 @@ name: foobar
 
 Every service must set both `container_name:` and `hostname:` to the same value. Antithesis sometimes uses `hostname` rather than `container_name` in it's log messages, so making sure they are the same will eliminate ambiguity during log analysis.
 
+Do not use underscores in `hostname` or `container_name` — underscores are not valid DNS label characters and can break name resolution. Use hyphens (e.g. `foobar-server`, not `foobar_server`).
+
 ## Image References
 
 Services use one of two patterns:
@@ -37,6 +39,7 @@ services:
     container_name: foobar-server
     hostname: foobar-server
     platform: linux/amd64
+    init: true
     build:
       context: ../..
       dockerfile: Dockerfile
@@ -46,6 +49,7 @@ services:
     container_name: foobar-postgres
     hostname: foobar-postgres
     platform: linux/amd64
+    init: true
     image: docker.io/library/postgres:17.2
 ```
 
@@ -60,6 +64,41 @@ The compose config must run without internet access. All images must be pre-buil
 ## setup_complete Signal
 
 Ensure at least one entrypoint emits the `setup_complete` event. Use `antithesis/setup-complete.sh` or call the SDK's setup complete method. Only emit once the system is healthy and ready for testing. Do not emit `setup_complete` from `antithesis/test/` or from any `first_` command; those commands do not start until after Antithesis has already observed `setup_complete`.
+
+## Runtime Compose Rules
+
+### Set `init: true` on every service
+
+Without it, the service's own entrypoint becomes pid 1 — and Antithesis cannot collect core dumps from a pid 1 process. `init: true` inserts a tiny init process so the real service runs under it and crashes remain diagnosable.
+
+### Order services with healthchecks, not plain `depends_on`
+
+Plain `depends_on` waits only for the container to start — not for the service inside it to be ready. Give each dependency a `healthcheck` and reference it with `condition: service_healthy`:
+
+```yaml
+services:
+  postgres:
+    image: docker.io/library/postgres:17.2
+    init: true
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 2s
+      timeout: 2s
+      retries: 30
+
+  server:
+    image: foobar-server:latest
+    init: true
+    depends_on:
+      postgres:
+        condition: service_healthy
+```
+
+### Things NOT to set
+
+- **`logging:` driver** — do NOT override. Antithesis collects stdout/stderr directly; a custom driver will still generate logs, but they will not appear in the debugging artifacts.
+- **`internal: true` on any network** — do NOT configure. It isolates the service from the Antithesis network and breaks connectivity.
+- **`pull_policy:`** — do NOT set. The Antithesis environment has no internet access, so anything that tries to pull at runtime will fail. Antithesis pulls all required images automatically before running `docker compose`.
 
 ## Named Volumes
 


### PR DESCRIPTION
## Summary

Adds four runtime `docker-compose.yaml` rules to `antithesis-setup`. Each captures a real footgun we've seen trip up users; together they bring the skill's generated compose configs closer to current Antithesis best practices.

## Changes

- **`init: true` on every service.** Without it, the service binary runs as pid 1, and Antithesis cannot collect core dumps from pid 1. `init: true` inserts a tiny init process so the real service runs underneath it and crashes remain diagnosable.
- **Healthchecks + `depends_on: condition: service_healthy`** instead of plain `depends_on`. Plain `depends_on` waits only for the container to start, not for the service inside to be ready — leading to startup races.
- **Hyphens, not underscores, in `container_name` / `hostname`.** Underscores are not valid DNS label characters and break cross-service name resolution. If your existing compose uses underscored names (e.g. `foobar_server`), rename them to hyphenated form (`foobar-server`).
- **Negative guidance** — do NOT set the following in the runtime compose:
  - custom `logging:` driver — Antithesis collects stdout/stderr directly; a custom driver bypasses that capture
  - `internal: true` on any network — isolates the service from the Antithesis network and breaks connectivity
  - `pull_policy:` — Antithesis pulls all required images automatically before running `docker compose`; setting this is redundant or conflicting

## Scope

Three files (+46/−1):
- `antithesis-setup/SKILL.md` — review-criteria bullets for each new rule
- `antithesis-setup/assets/antithesis/config/docker-compose.yaml` — template comments and `init: true` on the noop service
- `antithesis-setup/references/docker-compose.md` — new "Runtime Compose Rules" section, hyphens note added to the Container Name section, examples updated

Non-breaking: existing setups continue to work, but newly-generated configs follow these rules.

## Test plan

- [ ] Run setup skill on a fresh project — generated `docker-compose.yaml` includes `init: true` on every service and uses hyphenated names
- [ ] Run setup skill on a project with a dependency (e.g. postgres) — generates a `healthcheck` + `condition: service_healthy` rather than plain `depends_on`
- [ ] Verify generated config does not set `logging:`, `internal: true` networks, or `pull_policy:`