### PR TITLE
Add run log, known-issues, and journal to launch + triage skills

### DIFF
--- a/antithesis-launch/SKILL.md
+++ b/antithesis-launch/SKILL.md
@@ -40,6 +40,33 @@ Launch an Antithesis run in this order only:
 - Use the directory containing `docker-compose.yaml` as the `snouty validate <CONFIG>` and `snouty run --config <CONFIG>` argument.
 - Build against that exact file with `docker compose -f <CONFIG>/docker-compose.yaml build`. If `docker compose` is unavailable, fall back to `docker-compose -f ... build`.
 
+## Run Log
+
+Maintain a run log at `antithesis/scratchbook/run-log.md`. Each run gets a
+sequential integer ID (Run 1, Run 2, …). Before launching, read the run log
+to determine the next ID. **Immediately** after a successful `snouty run`,
+append an entry in the same response — do not defer or batch run log updates,
+because context compaction can cause deferred updates to be lost:
+
+```markdown
+## Run <N>
+
+- **Date**: <ISO 8601 date>
+- **Duration**: <minutes> minutes
+- **Description**: <what changed or what this run is testing>
+- **Branch**: <git branch>
+- **Config**: <config directory>
+- **snouty output**: <paste the run URL or submission ID from snouty>
+```
+
+If the run log does not exist yet, create it with a heading and the first
+entry. Include the run ID in both `--test-name` and `--description` so it
+appears in the triage report and runs browser (e.g., `--description "Run 14: fixed clone isolation in atomic push driver"`).
+
+If `antithesis/scratchbook/known-issues.md` exists, read it before launching.
+Note in the run log entry which known issues this run is expected to address
+(fixes deployed) and which are still outstanding.
+
 ## Run Arguments
 
 - Determine the webhook in this order: explicit user input, existing repo docs/scripts/examples, otherwise default to `basic_test`.
@@ -47,8 +74,8 @@ Launch an Antithesis run in this order only:
 - Always set all of these explicitly:
   - `--duration`: the user-provided duration
   - `--source`: repo name
-  - `--test-name`: repo name plus branch or config name
-  - `--description`: short, readable description of the run, including details such as the branch name, currently goal, or what you changed since the last run.
+  - `--test-name`: repo name plus branch or config name, prefixed with the run ID (e.g., `"Run 14 — myrepo/main"`)
+  - `--description`: short, readable description including the run ID, branch name, current goal, or what changed since the last run.
 
 ## Execution
 
@@ -71,6 +98,7 @@ snouty run \
 
 - Report the config directory, compose build command, validate command, and final `snouty run` command shape before submission.
 - If validation fails, stop immediately and show the failing command plus the key error.
+- Update `antithesis/scratchbook/run-log.md` with the new run entry.
 
 ## Self-Review
 
@@ -78,4 +106,6 @@ snouty run \
 - The build, validate, and run steps all point at the same config.
 - `snouty validate` succeeded before `snouty run` was invoked.
 - The run set `source`, `test-name`, `description`, and `duration` explicitly.
+- The run ID is sequential and appears in both `--test-name` and `--description`.
+- `antithesis/scratchbook/run-log.md` has been updated with the new run entry.
 - Missing blockers such as `duration`, `ANTITHESIS_REPOSITORY`, or an ambiguous config location caused a stop instead of a bad submission.

--- a/antithesis-triage/SKILL.md
+++ b/antithesis-triage/SKILL.md
@@ -30,6 +30,52 @@ Before starting, collect the following from the user:
 1. **Report URL or Tenant Name** (required) — A full triage report URL like `https://TENANT.antithesis.com/...` or just the tenant name. If neither is provided, check the `$ANTITHESIS_TENANT` environment variable. Only ask the user if you can't guess the tenant name.
 2. **What they want to know** — Are they investigating a specific failure? Getting a general overview? Comparing runs? This determines which workflow to follow.
 
+If `antithesis/scratchbook/run-log.md` exists, read it before triaging. The
+run log records what changed in each run (run ID, description, branch, date).
+Match the report's title or run metadata to a run log entry to understand
+what this run was testing and what changed since the previous run.
+
+When a failure looks like a bug that was already fixed, check the run log
+dates: if the fix was committed after this run was submitted, the failure is
+expected — note it as "known, fix not yet deployed in this run" and move on
+rather than investigating it again. Runs are often submitted in parallel with
+ongoing fixes, so later runs may already contain the fix while earlier runs
+do not.
+
+If `antithesis/scratchbook/known-issues.md` exists, read it before triaging.
+It tracks the status of every failure that has been investigated across runs.
+Before investigating a failure, check whether it is already listed:
+
+- **If listed and status is `confirmed SUT bug` or `investigating`**: note it
+  as a known issue in your summary, skip re-investigation unless the user asks.
+- **If listed and status is `fixed`**: check the run log to see whether the
+  fix was deployed in this run. If yes and the failure still appears, reopen
+  the investigation and update the entry. If the fix was not yet deployed,
+  note it as expected.
+- **If not listed**: investigate it, then add or update an entry.
+
+After triaging, **immediately** update `antithesis/scratchbook/run-log.md`
+with the run's results (status, key findings) and update
+`antithesis/scratchbook/known-issues.md` with any new findings or status
+changes. Do not defer these updates — context compaction can cause deferred
+writes to be lost. Each known-issues entry should have:
+
+- **Slug**: kebab-case identifier matching the property or bug name
+- **Property**: the failing property name
+- **Status**: `investigating`, `confirmed SUT bug`, `workload bug`, `fixed`,
+  `expected` (platform/environment), or `duplicate`
+- **First seen**: run ID where first observed
+- **Last seen**: run ID of most recent occurrence
+- **Notes**: one-line summary — what it is, what causes it, where the
+  evidence lives (journal entries, `bugs/` directory, mailing list drafts)
+
+If `antithesis/journal/` exists or the user asks for a journal entry, write
+a dated summary of your triage findings to
+`antithesis/journal/YYYY-MM-DD-<slug>.md`. Journal entries are narrative
+write-ups — deeper than the run log status line, capturing the investigation
+process, evidence, conclusions, and open questions. If the directory doesn't
+exist and the user hasn't asked for one, don't create it.
+
 ## Session management with `agent-browser`
 
 `agent-browser` has two session variables:
@@ -223,3 +269,4 @@ Review criteria:
 - Failed properties with available logs include actionable context: the assertion text, relevant log lines, and timeline context. Conclusions about failures are grounded in log evidence when logs exist
 - The summary distinguishes between what the report shows and what you interpret or recommend
 - If comparing runs, differences are grounded in data from both reports, not just one
+- `antithesis/scratchbook/known-issues.md` has been updated with any new failures or status changes from this triage


### PR DESCRIPTION
## Summary

Adds cross-run tracking state to the `antithesis-launch` and `antithesis-triage` skills via three new scratchbook files, so repeated runs on the same SUT build up institutional knowledge instead of re-investigating the same failures.

**Launch skill (`antithesis-launch/SKILL.md`, +32 lines)**
- Maintains `antithesis/scratchbook/run-log.md` — sequential run IDs with description, branch, date, status.
- Run log updates happen **immediately after submission**, not deferred. Context compaction can drop deferred writes, so the update is now a required step in the submit workflow rather than a post-hoc summary.
- Reads `known-issues.md` when present so the agent can note which open issues a run is expected to address.

**Triage skill (`antithesis-triage/SKILL.md`, +47 lines)**
- Reads `run-log.md` and `known-issues.md` before investigating, so the agent knows what changed between runs and which failures are already categorized.
- Short-circuits re-investigation when a failure is already listed as `confirmed SUT bug` / `investigating`, or when a `fixed` entry's fix post-dates the run.
- Each known-issues entry has a fixed shape (slug, property, status, first/last seen run IDs, notes) — status vocabulary is `investigating | confirmed SUT bug | workload bug | fixed | expected | duplicate`.
- Optional `antithesis/journal/YYYY-MM-DD-<slug>.md` narrative write-ups — only created if the journal directory already exists or the user asks for one. Not auto-provisioned.

The new guidance in triage's SKILL.md is placed right after "Gathering user input" and before "Session management with `agent-browser`" — it's conceptual context-loading, ahead of the mechanical session/auth/runtime setup.

## Test plan

- [ ] Launch skill: submit a run in a fresh project — `run-log.md` is created with run #1 and status updates happen immediately on submit, not at end-of-session.
- [ ] Launch skill: in a project with an existing `known-issues.md`, submit a run — agent surfaces which known issues this run is expected to exercise.
- [ ] Triage skill: run against a report without either file — workflow proceeds as before, no errors.
- [ ] Triage skill: run against a report with an existing `run-log.md` matching the report's run ID — agent references the run's description in its summary.
- [ ] Triage skill: with `known-issues.md` containing a `confirmed SUT bug` entry matching a current failure — agent notes "known issue" and does not re-investigate.
- [ ] Triage skill: with a `fixed` entry whose fix post-dates the run's submission — agent treats the failure as expected.
- [ ] Journal: without `antithesis/journal/` and without user asking — no journal file is created. With the directory present — a dated summary lands there.
- [ ] After triage completes, both `run-log.md` status and `known-issues.md` are updated before the session ends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)