### PR TITLE
Fix pass/fail count extraction for off-screen and summary-scoped properties

### DIFF
--- a/antithesis-triage/assets/antithesis-triage.js
+++ b/antithesis-triage/assets/antithesis-triage.js
@@ -383,17 +383,24 @@
     requireReportPage();
 
     // Expand all property containers in up to 32 passes (groups and leaves).
+    // Scroll through the properties section to ensure off-screen containers
+    // become visible before attempting to expand them.
     for (var i = 0; i < 32; i++) {
       var changed = false;
 
-      document
-        .querySelectorAll(".property__expander-button")
-        .forEach(function (btn) {
-          var container = btn.closest(".property-container");
-          if (!container || !isVisible(container) || isExpanded(container))
-            return;
-          if (click(btn)) changed = true;
-        });
+      var buttons = document.querySelectorAll(".property__expander-button");
+      for (var j = 0; j < buttons.length; j++) {
+        var btn = buttons[j];
+        var container = btn.closest(".property-container");
+        if (!container || isExpanded(container)) continue;
+
+        // Scroll into view if not visible, then expand
+        if (!isVisible(container)) {
+          container.scrollIntoView({ block: "center" });
+          await wait(50);
+        }
+        if (click(btn)) changed = true;
+      }
 
       if (!changed) break;
       await wait(250);
@@ -401,12 +408,24 @@
   }
 
   function exampleCounts(container) {
+    // Try the container's own text first
     var text = clean(container.textContent);
     var match = text.match(
       /([\d,]+)\s+passing\s+example.*?([\d,]+)\s+failing\s+example/,
     );
-    if (!match) return { passingCount: null, failingCount: null };
-    return { passingCount: match[1], failingCount: match[2] };
+    if (match) return { passingCount: match[1], failingCount: match[2] };
+
+    // If not found, look specifically in the run summary element
+    var summary = container.querySelector(".selected_property_run_summary");
+    if (summary) {
+      var summaryText = clean(summary.textContent);
+      match = summaryText.match(
+        /([\d,]+)\s+passing\s+example.*?([\d,]+)\s+failing\s+example/,
+      );
+      if (match) return { passingCount: match[1], failingCount: match[2] };
+    }
+
+    return { passingCount: null, failingCount: null };
   }
 
   // Assumes leaf properties are already expanded (waitForReady expands all


### PR DESCRIPTION
## What this is

This fixes a bug in getting the pass/fail counts from a property we noticed when using the triage skill. If there were a lot of properties and the triage skill was looking for a property deep in the list of properties, it was possible it could not read the pass/fail counts. The issue was the skill did not know how to scroll the property list in its internal browser if the property it was looking for was off of its virtual screen.  

## Summary

Two fixes to `antithesis-triage/assets/antithesis-triage.js` so `getAllProperties()` returns correct pass/fail counts on reports with many properties.

**`expandAllProperties()`** — Off-screen property containers were never expanded because the loop short-circuited on `!isVisible(container)`, and pass/fail counts are only rendered in the DOM after a property is expanded. Replaced `forEach` with an `async for` loop; when a container is not visible, it's now scrolled into view (`scrollIntoView({ block: "center" })`) with a 50ms wait before the expander is clicked. Reports with more properties than fit on screen now fully expand.

**`exampleCounts()`** — On some report layouts the `NN passing example... NN failing example` summary text is rendered in a child `.selected_property_run_summary` element rather than directly in the property container's own text. The old regex only looked at `container.textContent` and returned `null`/`null` whenever the summary was scoped. Added a fallback: if the top-level match fails, also check the scoped summary element, then fall through to null.

Both are narrow changes to existing functions. No API surface change — `getAllProperties()` / `visibleLeafProperties()` still return the same shape, just with accurate counts on more reports.

## Test plan

- [ ] Open a report with > ~20 properties (enough that some are off-screen on first render). Inject runtime, call `expandAllProperties()`. Scroll through — every property container is expanded.
- [ ] Same report: call `getAllProperties()`. Every leaf property returns non-null `passingCount` / `failingCount` (no silent `null`s).
- [ ] Open a report that renders pass/fail counts only in `.selected_property_run_summary` (rather than in the container's own text). Confirm counts are extracted from the scoped element.
- [ ] Open a small report where all properties fit on screen. Confirm no regression — expansion and counts still work.
- [ ] Run the `antithesis-triage-test/audit.js` integration test against a live tenant — `setup.getAllProperties` check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)