### PR TITLE
Expand changelog guidance in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,22 +25,95 @@ This uses `lychee` to check repository links, including raw URLs inside Markdown
 ## Changelog
 
 Changelog entries are managed automatically via PR labels. Do not edit
-`CHANGELOG.md` directly.
+`CHANGELOG.md` directly. When a labeled PR is merged, a bot adds the PR
+title to `CHANGELOG.md` under the date (UTC), with a link to the PR
+appended.
 
-Add one of these labels to PRs with notable changes:
+### When a PR needs an entry
 
-- `changelog - breaking` — changes existing behavior in a way that requires
-  users to adapt. The entry will be prefixed with `BREAKING CHANGE:`.
-- `changelog - non-breaking` — new features, fixes, and other improvements.
+If a skill user would notice a difference after updating, the PR needs an
+entry. That includes new skills, behavior changes in existing skills, bug
+fixes that affect output, and removals.
 
-If a PR has both labels, it gets a single entry with the `BREAKING CHANGE:`
-prefix.
+Internal changes — CI, refactors that don't change behavior, typo fixes
+in non-user-facing docs, dev tooling — don't need an entry. If you're
+not sure, the test is: would a skill user want to see this entry in
+`CHANGELOG.md`?
 
-Not every PR needs a label. Internal CI changes, typo fixes, and similar
-housekeeping generally don't.
+### One user-facing change per PR
 
-When a labeled PR is merged, a bot adds the PR title to `CHANGELOG.md` under
-the date (UTC). Write your PR title as a changelog entry.
+Split distinct user-facing changes into separate PRs. The bot produces
+one entry per PR, so bundling unrelated changes forces a single title to
+cover all of them, and labels become ambiguous when one change is
+breaking and the others aren't.
+
+Internal refactors and supporting changes can ride along in a user-facing
+PR when they're part of the same change. The test is whether you'd
+describe them separately to a user — if not, they belong together.
+
+### Labels
+
+Add exactly one of these labels to PRs that need an entry:
+
+- `changelog - breaking` — changes existing behavior in a way that
+  requires users to adapt. The bot prefixes the entry with
+  `BREAKING CHANGE:` automatically; don't put that prefix in your title.
+- `changelog - non-breaking` — new features, fixes, and other
+  improvements.
+
+If you split distinct changes into separate PRs as the previous section
+recommends, picking one label is straightforward. Don't apply both — the
+bot picks the first label it sees, which is not deterministic.
+
+The PR author normally applies the label before merge. External
+contributors who can't set labels should mention which label applies in
+the PR description so a maintainer can apply it. If a PR is merged
+without a label, follow up with a small PR that adds an entry to
+`CHANGELOG.md` directly under today's date — that's the only sanctioned
+case for editing `CHANGELOG.md` by hand.
+
+### Writing the PR title
+
+The PR title becomes the text of the changelog entry (the bot appends a
+link to the PR), so write the title as an entry:
+
+- Use the imperative mood: "Add support for X", "Fix Y when Z", "Remove
+  deprecated W".
+- Describe user-visible behavior, not internal structure. "Fix trailing
+  newline in `pony-ref` output" beats "Fix `_format_output` bug".
+- Assume the reader is scanning a list of changes between releases and
+  hasn't seen the PR. They should understand what changed without
+  clicking through.
+
+For breaking changes, the title should say what breaks for the user,
+not just what was renamed or removed internally. The bot prepends
+`BREAKING CHANGE:`; your title needs to convey what just changed for
+someone using these skills.
+
+### Writing the PR description
+
+The PR description is where a reader who clicked through the changelog
+entry lands. Lead with the user-facing change: what's different, who it
+affects, and whether action is required. Implementation notes and
+internal rationale can follow, but they shouldn't be the first thing a
+changelog reader sees. For example, a description for "Add support for
+X" might open:
+
+    Skills can now declare X in their frontmatter. Clients that read
+    skill metadata will surface X to the user before the skill loads;
+    skills without X behave as before.
+
+Trivial changes (typo fixes, small wording tweaks) don't need a body —
+the title is the description.
+
+For breaking changes, lead the description with a migration block: what
+to change, before and after. For example:
+
+    To update: rename any references to `/test-composer` to use
+    `/antithesis-test-template`, and uninstall the old skill.
+
+    Before: `/test-composer ...`
+    After:  `/antithesis-test-template ...`
 
 ## Validate changelog
 


### PR DESCRIPTION
The previous Changelog section in CONTRIBUTING.md described only the label mechanism. It didn't cover when a PR needs an entry, how to write the title so it reads as a changelog line, that the PR description is what readers click through to from the entry, or how to handle breaking changes. Someone unfamiliar with the convention had to reverse-engineer it.

This rewrite adds:

- Positive framing of when an entry is required (would a skill user notice?)
- One user-facing change per PR, with the test for what can ride along
- PR title guidance: imperative mood, user-visible behavior over internal structure, scannability without clicking through
- PR description guidance: lead with the user-facing change, with an example
- Breaking-change migration block guidance, with an example
- Process notes: who applies the label, what external contributors do, recovery path for missed labels

It also fixes one factually wrong statement carried over from the prior version: the "both labels → BREAKING CHANGE prefix" claim isn't enforced by the bot, which iterates labels and returns the first match. The new guidance directs contributors to apply exactly one label.

This is an internal documentation change, so no changelog label.