### PR TITLE
Ask about external references and record artifact provenance

### DIFF
--- a/antithesis-research/SKILL.md
+++ b/antithesis-research/SKILL.md
@@ -23,11 +23,17 @@ Research a target system and produce scratchbook artifacts that unblock the rest
 
 ## Prerequisites and Scoping
 
-Start from the repo, checked-in docs, and existing scratchbook files first. Ask the user only for blockers or scoping decisions you cannot infer safely, such as:
+At the start of every research run, ask the user about external references:
+
+> Before I start, are there docs, design notes, related repos, issue trackers, or anything else outside this directory tree that I should also consult? "Just this directory" is fine.
+
+Capture the answer verbatim. Each external reference becomes a `path` (or URL) plus a brief `why` note. The orchestrator (this skill) holds the answer for the full duration of the run and threads it as input to every reference workflow that produces a top-level artifact: `sut-discovery.md`, `sut-analysis.md`, `property-discovery.md`, `deployment-topology.md`, `property-evaluation.md`. Each of those references' agent-instruction sections accepts the list as input. The list is also recorded in the provenance frontmatter of every top-level artifact (see `references/scratchbook-setup.md`).
+
+Beyond the scope question, ask only for blockers or scoping decisions you cannot infer safely:
+
 - The repo or codebase location, if it is not already clear
 - Which subsystem or component matters most, if the work is narrower than the whole repo
 - Known incidents, closed bugs, or specific failure modes worth targeting
-- External documentation, issue trackers, or design docs not present in the repo
 
 If scratchbook artifacts already exist, treat them as inputs and extend them instead of rewriting them unless the user asks for a fresh pass.
 
@@ -77,9 +83,10 @@ Use the `antithesis-documentation` skill to ground Antithesis-specific terminolo
    `assert_sometimes!`, `assert_reachable!`, `assert_unreachable!`, or their
    non-macro equivalents). For each assertion found, record the file path, line
    number, assertion type, and message string. Write the results to
-   `antithesis/scratchbook/existing-assertions.md`. If no assertions are found,
-   write the file with a note confirming the codebase has no existing
-   instrumentation.
+   `antithesis/scratchbook/existing-assertions.md`. Begin the file with
+   provenance frontmatter per `references/scratchbook-setup.md`. If no
+   assertions are found, write the file with a note confirming the codebase has
+   no existing instrumentation.
 5. Read `references/property-discovery.md` and `references/property-catalog.md`
 6. Discover properties using the ensemble or single-agent workflow from `references/property-discovery.md`
 7. Read `references/deployment-topology.md`
@@ -139,6 +146,8 @@ Use the `antithesis-documentation` skill to ground Antithesis-specific terminolo
 - `antithesis/scratchbook/evaluation/synthesis.md`
 - `antithesis/scratchbook/evaluation/{lens}.md` (one per evaluation lens)
 
+All top-level scratchbook artifacts (everything in the list above except per-property evidence files) include provenance frontmatter recording `sut_path`, `commit`, `updated`, and `external_references`. Per-property evidence files inherit context from `property-catalog.md` and do not need their own frontmatter. See `references/scratchbook-setup.md`.
+
 These outputs should be concrete enough for the `antithesis-setup` skill and the `antithesis-workload` skill to use directly.
 
 ## Self-Review
@@ -150,7 +159,10 @@ Review criteria:
 - `antithesis/scratchbook/sut-analysis.md` exists and covers architecture, state management, concurrency model, and failure-prone areas
 - `antithesis/scratchbook/existing-assertions.md` exists and lists all Antithesis SDK assertions found in the codebase (or explicitly states none were found)
 - Evidence files correctly distinguish between instrumentation that already exists in the codebase, instrumentation that is partially present, and instrumentation that is missing — no evidence file suggests adding an assertion that is already there
-- `antithesis/scratchbook/property-catalog.md` exists, has provenance frontmatter (`commit` and `updated`), and lists concrete, testable properties — not vague goals like "test failover"
+- `antithesis/scratchbook/property-catalog.md` exists, has provenance frontmatter per `references/scratchbook-setup.md`, and lists concrete, testable properties — not vague goals like "test failover"
+- Every top-level artifact begins with provenance frontmatter per `references/scratchbook-setup.md`
+- The `external_references` list reflects the user's stated scope answer; entries that were referenced have a `why` note explaining their use
+- The scope question was asked at the start of the run, and the user's answer was passed to every sub-agent that performed analysis
 - Each property has a descriptive kebab-case slug as its canonical ID
 - Each property has a priority and a rationale for its chosen Antithesis assertion type (`Always`, `Sometimes`, `Reachable`, etc.)
 - Properties that need internal branch guidance or replay anchors call out likely SUT-side instrumentation points, not just workload-visible checks

--- a/antithesis-research/references/deployment-topology.md
+++ b/antithesis-research/references/deployment-topology.md
@@ -4,6 +4,10 @@
 
 Design the simplest container topology that covers the code you want to verify. Every extra container adds complexity and slows down Antithesis's exploration. Include only what is necessary.
 
+## External References
+
+If the user named external references during scoping (see `SKILL.md` "Prerequisites and Scoping"), check them for documented production topology, deployment diagrams, sizing guidance, or topology-relevant design notes before designing the minimal Antithesis topology. The orchestrator passes the list as input.
+
 ## Three Component Groups
 
 ### Dependencies
@@ -91,7 +95,7 @@ The workload client always needs the SDK to emit assertions. The SUT services ma
 
 ## Document the Plan
 
-Write to `antithesis/scratchbook/deployment-topology.md`. For each component, document:
+Write to `antithesis/scratchbook/deployment-topology.md`. Begin with provenance frontmatter per `references/scratchbook-setup.md`. For each component, document:
 
 - Container name
 - Image source (existing Dockerfile, official image, or new Dockerfile to create)
@@ -102,4 +106,4 @@ Write to `antithesis/scratchbook/deployment-topology.md`. For each component, do
 
 ## Output
 
-Write the topology plan to `antithesis/scratchbook/deployment-topology.md`.
+Write the topology plan to `antithesis/scratchbook/deployment-topology.md`, including provenance frontmatter (see `references/scratchbook-setup.md`).

--- a/antithesis-research/references/property-catalog.md
+++ b/antithesis-research/references/property-catalog.md
@@ -2,19 +2,7 @@
 
 ## Provenance
 
-The property catalog is a snapshot — it reflects the codebase at the time of analysis. Record this provenance as YAML frontmatter at the very beginning of the output file, before any heading. This lets downstream consumers know what state the catalog reflects.
-
-```yaml
----
-commit: <full git SHA of the codebase at time of analysis>
-updated: <ISO 8601 date of the analysis>
----
-```
-
-- **`commit`**: The HEAD commit of the target repository when the catalog was generated or last updated. Use the full 40-character SHA.
-- **`updated`**: The date the catalog was written or last updated. ISO 8601 format (`YYYY-MM-DD`).
-
-When updating an existing catalog (adding properties, revising after triage), update both fields to reflect the current codebase state.
+The property catalog is a snapshot — it reflects the codebase at the time of analysis. Begin the output file with the standard provenance frontmatter defined in `references/scratchbook-setup.md`. When updating an existing catalog (adding properties, revising after triage), refresh `commit` and `updated` to reflect the current codebase state.
 
 ## Property Types
 
@@ -204,6 +192,6 @@ This makes the "attempted" check in `SKILL.md` self-review verifiable: a reviewe
 
 ## Output
 
-Write the catalog to `antithesis/scratchbook/property-catalog.md`. Include the provenance frontmatter (see "Provenance" section above).
+Write the catalog to `antithesis/scratchbook/property-catalog.md`. Include provenance frontmatter per `references/scratchbook-setup.md`.
 Write per-property evidence files to `antithesis/scratchbook/properties/{slug}.md`.
 Write the property relationships to `antithesis/scratchbook/property-relationships.md`.

--- a/antithesis-research/references/property-discovery.md
+++ b/antithesis-research/references/property-discovery.md
@@ -139,6 +139,7 @@ Spawn one agent per focus. Each agent receives:
 - The path to `antithesis/scratchbook/existing-assertions.md` — read this before
   writing evidence files; for each property, note which assertions already exist
   vs. which are missing
+- The list of user-named external references with their `why` notes (from the scope question), so the agent can consult them as part of its analysis
 - These instructions:
 
 > Examine the codebase through the lens of your assigned attention focus. Produce
@@ -159,6 +160,7 @@ but receives different context. Instead of a "look for" list, it receives:
   the others search it.
 - The path to `antithesis/scratchbook/existing-assertions.md`
 - Access to the codebase
+- The list of user-named external references with their `why` notes (from the scope question), so the agent can consult them as part of its analysis
 
 ### Agent Output
 
@@ -223,6 +225,7 @@ After all agents complete, synthesize into a single property catalog:
   evidence, code paths, or failure mechanisms into clusters. Note any suspected
   dominance (where one property likely implies another). This is lightweight —
   flag connections you noticed during synthesis, don't do deep analysis.
+- **Apply provenance frontmatter:** Write `sut_path`, current `commit`, today's `updated`, and the list of `external_references` (from the user's scope answer) to `property-catalog.md` and `property-relationships.md` per `references/scratchbook-setup.md`.
 - **Investigate open questions:** see "Investigate Open Questions" below.
 
 #### Investigate Open Questions
@@ -260,47 +263,49 @@ focuses as a sequential checklist:
    consistency.
 6. Assign a descriptive kebab-case slug to each property and organize into final
    form per the catalog format.
-7. For each property, write an evidence file to `properties/{slug}.md` in the
+7. Apply provenance frontmatter to `property-catalog.md` per `references/scratchbook-setup.md`.
+8. For each property, write an evidence file to `properties/{slug}.md` in the
    scratchbook. Capture the supporting evidence, relevant code paths, failure
    scenario, and key observations you encountered during your passes. For each
    property's SUT-side instrumentation suggestions, cross-reference
    `existing-assertions.md` and explicitly note whether each suggested assertion
    already exists in the codebase, is partially present, or is missing.
-8. Review the complete property set and write `property-relationships.md` in the
+9. Review the complete property set and write `property-relationships.md` in the
    scratchbook. Group properties that share evidence, code paths, or failure
    mechanisms into clusters. Note any suspected dominance relationships. This is
    lightweight — flag connections you noticed during the passes, don't do deep
-   analysis.
-9. For each property with open questions in its evidence file, investigate the
-   code to answer them:
+   analysis. Apply provenance frontmatter per `references/scratchbook-setup.md`.
+10. For each property with open questions in its evidence file, investigate the
+    code to answer them:
 
-   - Read the evidence file's explanation of why each question matters and
-     trace the code to answer it.
-   - Don't fabricate answers. Tag `(partial: ...)` when partial findings exist;
-     tag `(needs human input)` only after exhausting investigation against code
-     and docs.
-   - Record an investigation log in the evidence file under an `### Investigation Log` heading (see `references/property-catalog.md` "Investigation Log") so
-     the "attempted" check in `SKILL.md` self-review is auditable.
-   - Update the evidence file with resolved answers and their implications,
-     including correcting any instrumentation suggestions against
-     `existing-assertions.md`.
-   - Sync the Open Questions list under each property from the evidence file,
-     following `references/property-catalog.md` ("Open Questions Conventions").
-     If a resolution makes a parametric term in the prose more specific,
-     refine the prose field accordingly.
-   - If an answer changes the property or invalidates it, update accordingly.
-     Mark invalidated properties in the catalog with the reason.
+    - Read the evidence file's explanation of why each question matters and
+      trace the code to answer it.
+    - Don't fabricate answers. Tag `(partial: ...)` when partial findings exist;
+      tag `(needs human input)` only after exhausting investigation against code
+      and docs.
+    - Record an investigation log in the evidence file under an `### Investigation Log` heading (see `references/property-catalog.md` "Investigation Log") so
+      the "attempted" check in `SKILL.md` self-review is auditable.
+    - Update the evidence file with resolved answers and their implications,
+      including correcting any instrumentation suggestions against
+      `existing-assertions.md`.
+    - Sync the Open Questions list under each property from the evidence file,
+      following `references/property-catalog.md` ("Open Questions Conventions").
+      If a resolution makes a parametric term in the prose more specific,
+      refine the prose field accordingly.
+    - If an answer changes the property or invalidates it, update accordingly.
+      Mark invalidated properties in the catalog with the reason.
 
-Treat each pass (1–10) as a fresh examination. Resist the pull to skip a focus
-because earlier passes "already covered" that area — the point is to look at the
-same code from different angles. The wildcard pass is the exception — it runs last
-and uses knowledge of the covered territory to find gaps.
+Treat each focus pass (Focuses 1–10) as a fresh examination. Resist the pull to
+skip a focus because earlier passes "already covered" that area — the point is
+to look at the same code from different angles. The wildcard pass is the
+exception — it runs last and uses knowledge of the covered territory to find
+gaps.
 
 ## Output
 
 - `antithesis/scratchbook/property-catalog.md` — using the format defined in
-  `references/property-catalog.md`, including provenance frontmatter with the
-  current git commit hash and date
+  `references/property-catalog.md`, including provenance frontmatter per
+  `references/scratchbook-setup.md`
 - `antithesis/scratchbook/properties/{slug}.md` — one per cataloged property
 - `antithesis/scratchbook/property-relationships.md` — suspected clusters and
-  connections
+  connections, including provenance frontmatter per `references/scratchbook-setup.md`

--- a/antithesis-research/references/property-evaluation.md
+++ b/antithesis-research/references/property-evaluation.md
@@ -165,18 +165,23 @@ Before spawning agents, create a directory for evaluation evidence files at
 - The path to `antithesis/scratchbook/properties/` (evidence files directory)
 - One evaluation lens (its full description from above)
 - The path to write its evidence file
+- The list of user-named external references with their `why` notes
+- The `sut_path`, current `commit`, and today's date (so the agent can write provenance frontmatter on its evidence file)
 - These instructions:
 
 > Evaluate the property catalog through the lens of your assigned evaluation
 > focus. Read the property evidence files when you need deeper context on a
 > specific property. Produce concrete, specific findings — not vague concerns.
 > Write your full analysis to the evidence file path provided, then return a
-> structured summary.
+> structured summary. Begin your evidence file with the standard provenance
+> frontmatter per `references/scratchbook-setup.md` before your analysis content.
 
-**Wildcard agent:** Receives the same inputs plus a one-line summary of each
-other lens (e.g., "Lens 1: Antithesis Fit — evaluates whether properties are in
-Antithesis's sweet spot vs. unit/integration test territory"). Does not receive
-the detailed guidance for other lenses.
+**Wildcard agent:** Receives the same inputs (including the user-named external
+references and the `sut_path`/`commit`/date for provenance frontmatter) plus a
+one-line summary of each other lens (e.g., "Lens 1: Antithesis Fit — evaluates
+whether properties are in Antithesis's sweet spot vs. unit/integration test
+territory"). Does not receive the detailed guidance for other lenses. Same
+provenance-frontmatter instruction as the standard agent applies.
 
 ### Agent Output Format
 
@@ -226,8 +231,11 @@ Provide the paths to each agent's evidence file so the synthesizer can dig in
 when needed — when scope assessments conflict, when a finding's summary is
 ambiguous, or when verifying that the evidence supports the concern.
 
-Write the synthesis results to `antithesis/scratchbook/evaluation/synthesis.md`.
-Include each finding, its category, and the action to be taken.
+Write the synthesis results to `antithesis/scratchbook/evaluation/synthesis.md`
+with provenance frontmatter per `references/scratchbook-setup.md`. The
+synthesizer is the writer for `synthesis.md` and has access to `sut_path`,
+`commit`, and `external_references` from the orchestrator. Include each finding,
+its category, and the action to be taken.
 
 ### Addressing Findings
 
@@ -247,6 +255,7 @@ After categorization:
    - The existing property catalog (to avoid duplicating existing properties)
    - The path to existing assertions
    - The property catalog format from `references/property-catalog.md`
+   - The list of user-named external references with their `why` notes
 
    Each agent returns properties in catalog format and writes evidence files.
    Targeted discovery agents may carry forward unresolved questions in their
@@ -255,7 +264,10 @@ After categorization:
    gap-fill properties into the catalog using the same deduplication and merge
    process from property discovery synthesis; this includes reconciling the
    Open Questions list under each new property. Update property relationships
-   with any new clusters.
+   with any new clusters. When re-writing the catalog with the new gap-fill
+   properties, refresh `commit` and `updated` in the provenance frontmatter to
+   reflect the current codebase state. Preserve the existing `sut_path` and
+   `external_references`.
 
 3. **Biases**: Collect and present to the human with the evaluation evidence.
    Include: the bias finding, the evidence from the evaluation agent(s), and
@@ -275,13 +287,15 @@ If your environment does not support sub-agents:
    assertions.
 2. For each evaluation lens 1-3 in order, make an explicit evaluation pass over
    the catalog. After each pass, record findings. Write the detailed analysis
-   for each lens to the corresponding evaluation evidence file.
+   for each lens to the corresponding evaluation evidence file. Begin each lens
+   evidence file with provenance frontmatter per `references/scratchbook-setup.md`.
 3. Run the wildcard pass (Lens 4) last. Unlike the other passes, the wildcard
    builds on awareness of what the first 3 found, looking for what they missed.
 4. Categorize all findings as Gap, Bias, or Refinement.
 5. Address findings: apply refinements, fill gaps by running targeted discovery
    passes, collect biases for the human.
-6. Write the synthesis to `antithesis/scratchbook/evaluation/synthesis.md`.
+6. Write the synthesis to `antithesis/scratchbook/evaluation/synthesis.md`. Begin
+   `synthesis.md` with provenance frontmatter per `references/scratchbook-setup.md`.
 
 Treat each lens pass (1-3) as a fresh examination. Resist the pull to skip a
 lens because an earlier pass "already covered" it.

--- a/antithesis-research/references/scratchbook-artifacts.md
+++ b/antithesis-research/references/scratchbook-artifacts.md
@@ -17,6 +17,10 @@ The scratchbook lives at `antithesis/scratchbook/` in the target repository and 
 | `evaluation/synthesis.md` | research | refinement (future) | Categorized evaluation findings and actions taken |
 | `evaluation/{lens}.md` | research | refinement (future) | Per-lens evaluation evidence |
 
+## Provenance
+
+Every top-level artifact begins with YAML provenance frontmatter recording `sut_path`, `commit`, `updated`, and `external_references`. The format is defined in `references/scratchbook-setup.md`. Downstream skills (`antithesis-setup`, `antithesis-workload`) verify this provenance against the user's current target before consuming the artifacts. An artifact lacking frontmatter is treated as legacy.
+
 ## Layout
 
 ```
@@ -54,7 +58,7 @@ This consistency means a slug uniquely identifies a property across all artifact
 
 The property catalog (`property-catalog.md`) is the human-readable summary of all discovered properties. It is designed for scanning and prioritization.
 
-The catalog carries YAML frontmatter that records provenance — the git commit and date of the codebase it was analyzed against. See `references/property-catalog.md` for the frontmatter format and the full catalog specification.
+The catalog carries the standard provenance frontmatter (see "Provenance" above and `references/scratchbook-setup.md`). The catalog also has structural requirements (slug format, property table layout, Open Questions conventions) documented in `references/property-catalog.md`.
 
 Each property's evidence file lives at `properties/{slug}.md`, where the slug matches the property's heading in the catalog.
 

--- a/antithesis-research/references/scratchbook-setup.md
+++ b/antithesis-research/references/scratchbook-setup.md
@@ -8,6 +8,46 @@ Create the `antithesis/scratchbook/` subdirectory for the Antithesis scratchbook
 
 If the directory or scratchbook files already exist, preserve them and extend them instead of overwriting them.
 
+## Provenance Frontmatter
+
+Every top-level artifact in the scratchbook must begin with YAML frontmatter recording what the artifact describes — which SUT, at what version, on what date, and which external references were consulted. This lets future readers and downstream skills (`antithesis-setup`, `antithesis-workload`) confirm the artifact still applies to the user's current target.
+
+```yaml
+---
+sut_path: <absolute path to the SUT root at time of writing>
+commit: <full 40-character git SHA, or "uncommitted" if the SUT is not under git>
+updated: YYYY-MM-DD
+external_references:
+  - path: <absolute path or URL>
+    why: <one-line note on why this was consulted>
+---
+```
+
+If the user said "just this directory" when asked the scope question, write `external_references: []`. The empty list means the question was asked and explicitly answered with no external references.
+
+Downstream skills (`antithesis-setup`, `antithesis-workload`) read whatever provenance fields are present in an artifact and describe what they find. They do not enforce a rigid schema match — older artifacts with fewer fields, or no frontmatter at all, are not "broken." An artifact lacking provenance frontmatter entirely predates this convention; downstream skills handle that case by simply describing what they found.
+
+Top-level artifacts requiring this frontmatter:
+
+- `sut-analysis.md`
+- `existing-assertions.md`
+- `property-catalog.md`
+- `deployment-topology.md`
+- `property-relationships.md`
+- `evaluation/synthesis.md`
+- `evaluation/{lens}.md`
+
+The rule applies uniformly even to artifacts whose `external_references` mirror another source. Two cases worth naming:
+
+- `property-relationships.md` is derivative of `property-catalog.md` (same write moment, same context). Copy `external_references` from the catalog when writing it.
+- `existing-assertions.md` is a fresh codebase scan written by the orchestrator inline (research SKILL.md workflow item 4), before discovery runs. There is no upstream artifact to copy from — the orchestrator writes the user's scope answer directly.
+
+In both cases, the resulting `external_references` matches the user's answer for this run. Uniformity simplifies downstream verification — one rule, applied everywhere — at negligible cost.
+
+Per-property evidence files (`properties/{slug}.md`) inherit context from `property-catalog.md` and do not need their own frontmatter.
+
+When updating an existing artifact, refresh `commit` and `updated` to reflect the current codebase state. Add new entries to `external_references` if additional sources were consulted; do not remove existing entries (the artifact already reflects them).
+
 ## What the Antithesis Scratchbook Is For
 
 The Antithesis scratchbook is the central location for durable Antithesis handoff artifacts. Use it to:
@@ -29,7 +69,7 @@ All research outputs should be written as markdown files in the Antithesis scrat
 - `antithesis/scratchbook/evaluation/synthesis.md` — Categorized evaluation findings and actions taken
 - `antithesis/scratchbook/evaluation/{lens}.md` — Per-lens evaluation evidence (antithesis-fit, coverage-balance, implementability, wildcard)
 
-When starting from scratch, initialize each file with a short summary section plus explicit `Assumptions` and `Open Questions` headings. This makes later iterations and handoffs easier.
+When starting from scratch, initialize each file with provenance frontmatter (see "Provenance Frontmatter" above), then a short summary section plus explicit `Assumptions` and `Open Questions` headings. This makes later iterations and handoffs easier.
 
 Create the `antithesis/scratchbook/properties/` directory when writing the first property evidence file.
 

--- a/antithesis-research/references/sut-analysis.md
+++ b/antithesis-research/references/sut-analysis.md
@@ -13,7 +13,7 @@ Build a comprehensive understanding of the system — its architecture, componen
 
 ## Research External Sources
 
-If the user provides documentation links, GitHub issues, or design docs — read them. Focus on:
+Read the user-named external references gathered during scoping (see `SKILL.md` "Prerequisites and Scoping"). They are typically:
 
 - **Architecture docs:** Reveal the intended design and the guarantees the system claims to make.
 - **Open bugs (especially in target components):** These are known weaknesses. Antithesis may find deeper variants.
@@ -68,4 +68,4 @@ These partial failure modes often reveal the most interesting bugs because syste
 
 ## Output
 
-Write the analysis to `antithesis/scratchbook/sut-analysis.md`.
+Write the analysis to `antithesis/scratchbook/sut-analysis.md`. Begin with provenance frontmatter (see `references/scratchbook-setup.md`).

--- a/antithesis-research/references/sut-discovery.md
+++ b/antithesis-research/references/sut-discovery.md
@@ -14,7 +14,8 @@ but filters its work through its assigned focus.
 ## Prerequisites
 
 - The repo or codebase location is known
-- Any user-provided documentation links, issue trackers, or design docs are available
+- The user has answered the scope question (see `SKILL.md` "Prerequisites and Scoping")
+- Any user-named external references are available
 
 ## Attention Focuses
 
@@ -152,6 +153,7 @@ Spawn one agent per focus. Each agent receives:
 - The general SUT analysis methodology from `references/sut-analysis.md`
 - One attention focus (its full description and "look for" guidance from above)
 - Access to the codebase, documentation, and issue tracker
+- The list of user-named external references with their `why` notes (from the scope question), so the agent can consult them as part of its analysis
 - These instructions:
 
 > Examine the system through the lens of your assigned attention focus, using the
@@ -170,6 +172,7 @@ but receives different context. Instead of a "look for" list, it receives:
   the detailed "Look for:" lists — the wildcard should know what territory is
   covered, not how the others search it.
 - Access to the codebase, documentation, and issue tracker
+- The list of user-named external references with their `why` notes (from the scope question), so the agent can consult them as part of its analysis
 
 ### Agent Output Format
 
@@ -217,4 +220,4 @@ last and uses knowledge of the covered territory to find gaps.
 
 ## Output
 
-The output feeds into `antithesis/scratchbook/sut-analysis.md`.
+The output feeds into `antithesis/scratchbook/sut-analysis.md`, including provenance frontmatter per `references/scratchbook-setup.md`.

--- a/antithesis-setup/SKILL.md
+++ b/antithesis-setup/SKILL.md
@@ -33,6 +33,21 @@ Success means:
 
   Do not attempt to proceed without research artifacts. The setup skill will make significantly worse decisions without the context that research provides.
 
+- **Verify research provenance.** Setup runs once per project and produces durable, expensive output (Dockerfiles, compose, instrumentation), so misalignment is costly. Read whatever provenance frontmatter is present in `antithesis/scratchbook/sut-analysis.md` and `antithesis/scratchbook/deployment-topology.md`. Use whatever fields you find — the schema may evolve over time, so don't treat partial or older frontmatter as broken. Describe what you found in plain language. Examples:
+
+  - Full schema: "this scratchbook is for SUT at `/path/X` at commit `abc12345abcd` (2026-05-05), external refs: A, B."
+  - Partial: "the catalog records `commit` and `updated` but no `sut_path` or `external_references`."
+  - Absent: "no provenance recorded; the scratchbook predates this convention."
+  - Disagreement across files: "sut-analysis is for `/path/A` at commit `abc`; deployment-topology is for `/path/B` at commit `def` — these disagree."
+
+  Then ask the user:
+
+  > Is this still the system you're targeting?
+
+  If the user says no, **do not proceed**. Stop and tell the user to re-run `antithesis-research`. Setup against confirmed-stale research will produce mismatched scaffolding.
+
+  The user-facing commit display uses the short hash (first 12 characters) for readability; the frontmatter still stores the full SHA.
+
 - DO NOT PROCEED if `snouty` is not installed. See `https://raw.githubusercontent.com/antithesishq/snouty/refs/heads/main/README.md` for installation options.
 
 ## Documentation Grounding
@@ -101,3 +116,4 @@ Review criteria:
 - Every service has `NO_COLOR=1` set in its environment (via docker-compose.yaml and/or Dockerfile) to prevent ANSI escape codes in container output
 - The harness is ready for the `antithesis-workload` skill — test template directories exist or are wired for later use
 - If the user asks to launch a run, the `antithesis-launch` skill is used instead of running `snouty run` directly
+- Whatever research provenance was present in `sut-analysis.md` and `deployment-topology.md` was described to the user and confirmed before scaffolding began (provenance frontmatter format is defined in the `antithesis-research` skill, `references/scratchbook-setup.md`)

--- a/antithesis-workload/SKILL.md
+++ b/antithesis-workload/SKILL.md
@@ -49,7 +49,13 @@ The detection task: for each property in the catalog, search the existing test a
 
 ## Present and recommend
 
-Note the catalog's provenance frontmatter (`commit` and `updated` fields) and include it when presenting status — e.g., "The property catalog is up-to-date as of `<commit short hash>` (`<date>`)." This lets the user judge whether the catalog reflects the current codebase or needs re-research.
+Read whatever provenance frontmatter is present in the catalog and include it when presenting status. Use whatever fields you find — the schema may evolve over time, so don't treat partial or older frontmatter as broken. Describe what's there in plain language. Examples:
+
+- Full schema: "working from the catalog at commit `abc12345abcd` (2026-05-05), SUT path `/foo`, external refs: A, B."
+- Partial: "working from the catalog at commit `abc12345abcd` (2026-05-05) — no SUT path or external refs recorded."
+- Absent: "working from the catalog (no provenance recorded; predates the convention)."
+
+Workload runs every property cycle, so don't ask the user to re-confirm provenance every run — display it as context and continue. The user will speak up if it no longer matches the system they're working on. The user-facing commit display uses the short hash (first 12 characters) for readability; the frontmatter still stores the full SHA.
 
 Show the user the status of each property, then recommend one to implement next. Prefer partially-implemented properties that need completion, then unimplemented properties that cluster with recently implemented ones (see `antithesis/scratchbook/property-relationships.md`), then other high-priority unimplemented properties. Wait for the user to confirm or choose differently before proceeding.
 
@@ -140,6 +146,7 @@ Review criteria:
 - No test command is responsible for Antithesis lifecycle signaling; `setup_complete` is emitted before test commands begin
 - Test templates are structured correctly at the path that will map to `/opt/antithesis/test/v1/{name}/` in the container
 - Helper files or directories are prefixed with `helper_` so Antithesis ignores them
-- `antithesis/scratchbook/property-catalog.md` is updated to reflect the implementation status of every property in scope, with provenance frontmatter (`commit` and `updated`) reflecting the current codebase state
+- Whatever provenance frontmatter was present in the catalog was displayed when presenting status, so the user could spot a mismatch with the system they're working on
+- `antithesis/scratchbook/property-catalog.md` is updated to reflect the implementation status of every property in scope, with provenance frontmatter reflecting the current codebase state (refresh `commit` and `updated`; preserve `sut_path` and `external_references` from the existing catalog). The frontmatter format is defined in the `antithesis-research` skill, `references/scratchbook-setup.md`.
 - Assertions are in workload code or surgical SUT locations — not scattered across production paths
 - Use `snouty validate` on `antithesis/config` to ensure that the compose setup can reach setup complete and any configured test-templates work. Make sure to build the latest images before running validate.

--- a/antithesis-workload/references/iteration.md
+++ b/antithesis-workload/references/iteration.md
@@ -26,7 +26,7 @@ After running `antithesis-triage` on a completed test run and reviewing the resu
 
 ## Update the Antithesis scratchbook
 
-Update `antithesis/scratchbook/property-catalog.md` whenever properties are added or changed — including the provenance frontmatter (`commit` and `updated` fields) so the catalog reflects the current codebase state. For new properties, write a corresponding evidence file at `antithesis/scratchbook/properties/{slug}.md`. For changed properties, update the existing evidence file to reflect the new understanding.
+Update `antithesis/scratchbook/property-catalog.md` whenever properties are added or changed — refresh `commit` and `updated` in the provenance frontmatter; preserve `sut_path` and `external_references` from the existing catalog. The frontmatter format is defined in the `antithesis-research` skill, `references/scratchbook-setup.md`. For new properties, write a corresponding evidence file at `antithesis/scratchbook/properties/{slug}.md`. For changed properties, update the existing evidence file to reflect the new understanding.
 
 When the work resolves an open question on a property (or surfaces a new one), keep the Open Questions list under the property in sync with the evidence file. See the `antithesis-research` skill, `references/property-catalog.md` ("Open Questions Conventions").
 


### PR DESCRIPTION
Research previously assumed the working directory was the project root. That falls apart for monorepo subdirectories, multi-repo projects, and docs that live in a separate place — research silently produced incomplete output when scope spanned more than one directory.

Now:

- `antithesis-research` asks the user once at the start of every run whether anything outside the working tree should be consulted ("just this directory" is fine), and threads the answer to every sub-agent that performs analysis.
- Top-level scratchbook artifacts carry provenance frontmatter (`sut_path`, `commit`, `updated`, `external_references`). The schema is defined once in `antithesis-research/references/scratchbook-setup.md`; every other reference delegates to it.
- `antithesis-setup` reads whatever provenance fields are present in `sut-analysis.md` and `deployment-topology.md`, describes what it found in plain language, and asks the user to confirm before scaffolding. On confirmed mismatch it refuses to proceed.
- `antithesis-workload` reads whatever provenance fields are present in `property-catalog.md` and displays them as context every cycle — no re-confirmation prompt, since workload runs constantly. The user speaks up if the provenance no longer matches the system they're working on.
- The verification logic is "use what's there" — older artifacts with fewer fields, or no frontmatter at all, are not treated as broken. Schema can evolve without invalidating existing scratchbooks.

The scope question is asked **unconditionally** on every research run, including extension runs. A "use last answer as default" mechanism is deliberately deferred — it rides along with the open re-run-research question.

Out of scope: persisted scope file, detect-and-prompt logic, scope questions in setup/workload (setup asks once for confirmation, but doesn't ask scope), categorized external-reference fields.