### PR TITLE
Add antithesis-k8s-onboarding-assistance skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ Enable AI agents to set up Antithesis, bootstrap your first Antithesis test, lau
 
 **`antithesis-research` produces planning artifacts that you should review carefully.**
 
+`antithesis-k8s-onboarding-assistance` is for customers running on Kubernetes. It's an interview-driven assistant that helps the customer (and the Antithesis engagement team) figure out what's in the k8s setup, what to keep/drop/stub for testing, and produces structured questions the customer can take to their ops team. K8s customers run it before `antithesis-setup`.
+
+> [!NOTE]
+> `antithesis-k8s-onboarding-assistance` is more experimental than the other skills here. Unlike the others, we can't realistically dogfood it without a real customer engagement — we genuinely don't know how well it works in practice yet. If you use it, please file feedback aggressively. Every real engagement teaches us something we couldn't learn synthetically.
+
 `antithesis-triage` enables agents to parse and analyze the results of your Antithesis test runs.
 
 `antithesis-debug` enables agents to interactively debug Antithesis test runs using the [multiverse debugger](https://antithesis.com/docs/multiverse_debugging/) — inspecting container filesystems and runtime state, running shell commands, and extracting evidence from inside the Antithesis environment.
@@ -38,6 +43,8 @@ Enable AI agents to set up Antithesis, bootstrap your first Antithesis test, lau
 </p>
 
 We recommend that you run `antithesis-research`, `antithesis-setup`, and `antithesis-workload` in order and in separate fresh contexts. After running each skill review all of the changes made so far, and iterate on them before continuing to the next skill.
+
+If your system runs on Kubernetes, run `antithesis-k8s-onboarding-assistance` before `antithesis-setup`. It works with you to figure out which parts of your production k8s setup belong in the test environment, what should be stubbed, and what to drop.
 
 Once the harness is in place, use `antithesis-launch` to run `docker compose build`, `snouty validate`, and `snouty run` in the right order. We recommend running this after the setup and workload skills to ensure everything is working well.
 
@@ -92,6 +99,19 @@ Here's an example:
 
 This skill implements Antithesis workloads and places all the test commands and supporting files under `antithesis/test/`, adds assertions to carefully chosen locations in the SUT.
 
+### antithesis-k8s-onboarding-assistance
+
+```
+/antithesis-k8s-onboarding-assistance We use Kubernetes in production. Help us figure out the test environment for Antithesis.
+```
+
+This skill produces the following artifacts, relative to the project directory:
+
+- `antithesis/scratchbook/k8s-minimization.md` — the final report describing the test environment (components, dependencies, stubs, decisions). Once setup gains k8s support, setup reads this file directly; until then, it serves as a structured handoff packet for the Antithesis engagement team.
+- `antithesis/scratchbook/k8s-minimization-work/working.md` — the live decision history across passes, including reversals and open assumptions.
+- `antithesis/scratchbook/k8s-minimization-work/ops-questions.md` — the current open questions for the customer's ops team, formatted for paste-into-Slack response.
+- `antithesis/scratchbook/k8s-minimization-work/escalation.md` — generated on demand if the customer needs to loop in their Antithesis engagement team for help.
+
 ### antithesis-launch
 
 ```
@@ -118,14 +138,15 @@ Here are the tools each skill may invoke, so you can pre-approve them if you pre
 
 | Skill                      | Tools used                      |
 | -------------------------- | ------------------------------- |
-| `antithesis-research`      | No explicit external tools      |
-| `antithesis-setup`         | `docker`/`podman`, `snouty`     |
-| `antithesis-workload`      | `snouty`                        |
-| `antithesis-launch`        | `docker`/`podman`, `snouty`     |
-| `antithesis-triage`        | `snouty`, `agent-browser`, `jq` |
-| `antithesis-debug`         | `agent-browser`                 |
-| `antithesis-query-logs`    | `snouty`, `agent-browser`       |
-| `antithesis-documentation` | `snouty docs`                   |
+| `antithesis-research`                  | No explicit external tools      |
+| `antithesis-k8s-onboarding-assistance` | No explicit external tools      |
+| `antithesis-setup`                     | `docker`/`podman`, `snouty`     |
+| `antithesis-workload`                  | `snouty`                        |
+| `antithesis-launch`                    | `docker`/`podman`, `snouty`     |
+| `antithesis-triage`                    | `snouty`, `agent-browser`, `jq` |
+| `antithesis-debug`                     | `agent-browser`                 |
+| `antithesis-query-logs`                | `snouty`, `agent-browser`       |
+| `antithesis-documentation`             | `snouty docs`                   |
 
 ## Install
 
@@ -142,6 +163,7 @@ The installer presents an interactive menu. Choose the following options:
 1. **Skills** — select the skills you need:
    - `antithesis-documentation`
    - `antithesis-research`
+   - `antithesis-k8s-onboarding-assistance`
    - `antithesis-setup`
    - `antithesis-triage`
    - `antithesis-workload`

--- a/antithesis-k8s-onboarding-assistance/SKILL.md
+++ b/antithesis-k8s-onboarding-assistance/SKILL.md
@@ -1,0 +1,458 @@
+---
+name: antithesis-k8s-onboarding-assistance
+description: >
+  Interview-driven assistant for customers with Kubernetes-based production
+  setups who are getting started with Antithesis. Helps the customer (and
+  the Antithesis engagement team) figure out what their k8s setup contains,
+  what to keep, drop, or stub for testing, and produces structured
+  questions for ops plus an escalation packet when stuck.
+metadata:
+  version: "2026-04-28 unreleased"
+---
+
+# Antithesis K8s Onboarding Assistance
+
+## Purpose and Goal
+
+Help customers running on Kubernetes minimize their production manifests down to a form `antithesis-setup` can use to construct an Antithesis test environment. The output is a structured analysis report — not modified YAML.
+
+Success means:
+
+- `antithesis/scratchbook/k8s-minimization.md` is a stable, reviewable report describing the components, dependencies, stub strategies, and decisions setup will need to construct the test environment for a k8s-based SUT
+- `antithesis/scratchbook/k8s-minimization-work/working.md` captures the live decision history across passes — including reversals, defaulted decisions, and open assumptions
+- The customer has either (a) finished work on this skill with the final report ready for setup, or (b) an escalation packet ready to share with their Antithesis engagement team
+
+This skill applies only to customers running on Kubernetes. Customers using Docker Compose directly skip this skill and go straight from `antithesis-research` to `antithesis-setup`.
+
+Note: `antithesis-setup` currently builds Docker Compose harnesses. Setup-side k8s support is a separate effort. When that effort lands, this skill's final report becomes setup's input for k8s customers; until then, the report is a structured handoff to the Antithesis engagement team rather than a direct setup input. The skill produces the same artifact regardless of which path the consumer takes downstream.
+
+## Prerequisites and Scoping
+
+Before this skill can do useful work, it needs scope information about what's being tested: SUT identity, test boundary, and success criteria for the app running correctly.
+
+Two ways to get that information:
+
+- **Read it from a prior research artifact.** Look for `antithesis/scratchbook/sut-analysis.md`. If it exists, read the SUT identity from it.
+- **Interview the customer.** Ask what they're testing. Capture SUT identity, test boundary, and success criteria from the conversation.
+
+Either source is fine. The working file records the origin so it's clear later where the scope information came from.
+
+If neither path produces enough scope to proceed (no `sut-analysis.md`, and the customer can't articulate scope), that's a blocker — not a workflow redirect. Explain that the skill needs to know what's being tested before it can do useful work, and offer the escalation packet path so the customer can loop in their Antithesis engagement team.
+
+This skill collects substantial additional context regardless of where the scope information came from — the customer's k8s artifacts, ops contact, sensitive-data handling preferences, success criteria detail. Scope is the gate to start; intake supplies the rest.
+
+This skill never runs `kubectl`, `helm`, `kustomize`, `docker`, `kind`, `k3d`, or any other cluster-touching command. Customers may run commands themselves and paste the output back; the skill reads pasted output but does not execute.
+
+## Definitions and Concepts
+
+- **SUT:** System under test (term inherited from `antithesis-research`)
+- **Horizontal minimization:** Deciding which components in the customer's manifests are part of the test scope at all (SUT, dependency, or out-of-scope)
+- **Vertical minimization:** For a component that is in scope, stripping platform/cloud/observability cruft so it can run in a single-node test environment
+- **Single-node test environment:** Antithesis explores timelines deterministically against a small, fixed deployment. Multi-node distributed-system features (cross-node consensus, cluster autoscaling, real load balancers, network policies enforced by a CNI) don't add value in this environment — they add state space and non-determinism. "Single-node" doesn't mean Antithesis can't test distributed-system correctness; it means the test deployment runs as one Antithesis-managed environment, with multiple replicas or services co-located rather than spread across real nodes.
+- **Working file:** Live, growing artifact across passes (`antithesis/scratchbook/k8s-minimization-work/working.md`)
+- **Final report:** Stable snapshot of the working file's current state, generated when handoff readiness passes (`antithesis/scratchbook/k8s-minimization.md`)
+- **Landmine:** A platform-layer construct that is commonly minimized away, with a known recipe (Istio, cert-manager, external-secrets, etc.)
+- **Status field:** Each entry in the working file has a status of `Confirmed`, `Defaulted`, or `Open`. Handoff readiness fails if any `Open` entries remain.
+
+## Documentation Grounding
+
+Use the `antithesis-documentation` skill to ground Antithesis-specific terminology.
+
+This skill does not have its own dedicated Antithesis documentation pages — it bridges between `antithesis-research` and `antithesis-setup`. For any Antithesis-domain concept (SUT, properties, scratchbook conventions, deployment topology), defer to those skills' documentation grounding.
+
+## Core Principles
+
+**No archaeology.** Default direction is minimize. The bar to keep something is "we have a reason to believe the app needs this." The bar to drop is "this looks like platform/cluster concerns." Optimize for rate-of-customers-reaching-success, not correctness-on-each-decision. The two error modes are not symmetric:
+
+- *Drop something we shouldn't*: caught at setup or runtime, recoverable in minutes.
+- *Ask too many archaeology questions*: customer gives up. Unrecoverable.
+
+Lean toward the first.
+
+**Defaults are aggressive; the customer always overrides; every decision is visible.** Record what was decided and why in the working file. The customer can scan it and push back on any decision without justifying themselves. Reversals are first-class — when a prior decision is overturned, show the reversal explicitly in history rather than silently rewriting.
+
+**Skill never runs cluster commands.** This is non-negotiable. Customer's machine, customer's kubeconfig, customer's cluster — the skill describes commands and reads pasted output, never executes.
+
+**Never tell the customer "no."** When the work hits a wall — ops unresponsive, a hard architectural problem, customer is stuck — produce an escalation packet for the Antithesis engagement team. Dead ends become warm handoffs.
+
+**Fidelity vs. speed is a calibrated tradeoff, surfaced explicitly.** When applying a landmine default that has a meaningful fidelity impact (e.g., dropping Istio when the customer tests with Istio in prod), state the fidelity cost and let the customer choose. Don't silently optimize for speed when the customer cares about fidelity.
+
+**Keep the customer in the loop on what's about to leave their environment.** When generating the escalation packet, prompt for sensitive data review before producing the document, even if the customer already gave a sensitive-data preference at intake. Different audience, different stakes.
+
+## Skill Flow
+
+Eight phases. On each invocation, read the working file first to determine where you are. The working file's frontmatter records `current_phase`, so you can resume cleanly across sessions.
+
+1. **Confirm prerequisites.** Look for `sut-analysis.md` or interview the customer for research-equivalent scope. If neither path produces enough scope to proceed, treat as a blocker and offer the escalation packet path. (See *Phase Guidance → Confirm prerequisites*.)
+
+2. **Greeting / expectation-setting.** First-contact only. Set the frame: multi-pass, aggressive cuts, fidelity-vs-speed tradeoff, customer can override, ops-questions are the work, escalation exists. (See *Phase Guidance → Greeting*.)
+
+3. **Intake.** Conversational with internal checklist. Cover: sensitive-data handling first, then `helm`/`kustomize` rendering if needed, then ops contact, artifact form, customer comfort level, app success criteria. (See *Phase Guidance → Intake*.)
+
+4. **Horizontal classification.** Classify each component as SUT / dep-real / dep-stub / out-of-scope. Built from research scope + call graph from manifests. (See `references/horizontal-classification.md`.)
+
+5. **Customer review checkpoint.** Explicit pause. Present the horizontal cut; customer pushes back. Vertical work on a misclassified component is the most expensive failure mode in this skill — do not skip the pause. (See *Phase Guidance → Customer review checkpoint*.)
+
+6. **Vertical classification.** For each kept component, strip platform/cloud/observability cruft. (See `references/vertical-classification.md` and `references/landmines.md`.)
+
+7. **Stub strategy.** For each stubbed dependency, describe what setup needs to fake — kind, calls made, response shapes, behaviors required, ordering constraints. (See *Phase Guidance → Stub strategy*.)
+
+8. **Compile final report + handoff readiness check.** Roll the work into the final report only if all checklist items pass — including no `Open` status items remaining. (See *Phase Guidance → Compile and handoff*.)
+
+The flow is multi-pass. Customer goes to ops between sessions. Skill resumes from where the working file says we are.
+
+**Phase transitions.** When entering each phase, update `current_phase` in the working file's frontmatter to the phase number you're entering. The reference files for phases 4 and 6 also call out specific phase advancement points; otherwise the rule is straightforward — `current_phase` always reflects the phase the skill is currently in or about to begin on resumption. Phases 1 and 2 typically run only on first contact and don't get re-entered; the working file is created in phase 1 with `current_phase: 1` and advances forward from there.
+
+**`pass_count` and `last_pass` semantics.** A "pass" is a customer-ops round-trip. Increment `pass_count` and update `last_pass` to today's date when:
+- Generating a fresh `ops-questions.md` after the customer returns with answers from ops
+- The customer arrives with new manifest content (rendered Helm output, additional files) that triggers re-classification
+- The customer requests a new pass explicitly
+
+Multiple skill invocations within a single customer-ops round-trip don't count as separate passes. The `pass_count` is what's reflected in the `Pass <N>` header of `ops-questions.md`.
+
+## Phase Guidance
+
+### Confirm prerequisites
+
+This phase runs only on first invocation; subsequent invocations resume from whatever phase the working file's `current_phase` indicates and skip this section.
+
+**Locate the scratchbook.** `antithesis/scratchbook/` lives at the root of the customer's project repository (the directory the skill is invoked in). It's a shared convention across the Antithesis skill family (see `antithesis-research/references/scratchbook-setup.md`). If `antithesis/scratchbook/` doesn't exist, create it. Then create `antithesis/scratchbook/k8s-minimization-work/` for this skill's working artifacts.
+
+**Get scope information.** Read `antithesis/scratchbook/sut-analysis.md` if it exists — that's the standard source. If it doesn't exist, ask the customer: "what specifically are you testing — a single service, a flow across services, a database, an end-to-end customer journey?" Capture SUT identity, test boundary, and success criteria from whichever source produces them.
+
+**If scope can't be established at all** — no `sut-analysis.md`, and the customer can't articulate scope — that's a blocker, not a workflow redirect. Explain we need scope information before the skill can do useful work, and offer the escalation packet path so the customer can loop in their Antithesis engagement team.
+
+**Create the working file.** Initialize `antithesis/scratchbook/k8s-minimization-work/working.md`. Populate the *Application overview* section with the SUT identity, test boundary, success criteria, and the *origin* of these (whether `sut-analysis.md` or interview).
+
+### Greeting
+
+First contact only. Use these beats:
+
+- This will take multiple passes. That's normal, not a failure mode.
+- We build artifacts under `antithesis/scratchbook/k8s-minimization-work/` that persist between sessions, plus a final report when we're done.
+- Each pass usually ends with you having questions to take to ops; that's the work.
+- I'll be aggressive about cutting Kubernetes platform machinery — service mesh, monitoring, autoscaling, secret operators, and similar. Sometimes I'll cut something the app actually needs; we add it back if it surfaces. Speed-to-running over perfect-on-first-try.
+- This skill stops at the final report. The next step is `antithesis-setup`, where the test environment actually gets constructed; minimization done is not the same as ready to run.
+- If we hit something we can't resolve, we produce a packet you can hand to your Antithesis engagement team — you're not stuck, you're escalating with context.
+
+End with: "have you done this kind of minimization before, or is this your first time?" — calibrates how much hand-holding to do without making it feel like a quiz.
+
+**Advance to phase 3** (intake) when the customer has acknowledged the framing and answered the calibration question.
+
+### Intake
+
+Conversational with internal checklist. Scan the working directory first for k8s-shaped artifacts (`*.yaml` manifests, `Chart.yaml`, `kustomization.yaml`, ArgoCD `Application` files); use what you find to scope the questions. A 20-question intake form will lose people; ask only what you can't infer.
+
+Top-level steps:
+
+1. **Sensitive-data handling.** Before the customer pastes anything, ask: "manifests often contain things you might not want in this conversation — internal hostnames, embedded secrets, account IDs, customer-private domain names. Do any of those apply, and if so how do you want to handle them: redact in place, mask, or share as-is?" Capture the answer in the working file's metadata. Respect the preference for the rest of the engagement, and re-prompt at any later point where new content might be sensitive (escalation packet generation, ops-questions documents that quote manifests).
+
+2. **Render Helm / Kustomize if needed.** If the customer brought templates rather than rendered output, walk them through running `helm template` (with their prod values) or `kustomize build` and pasting the result back. Templates by themselves are not analyzable — values determine what's actually deployed.
+
+3. **Internal checklist** — establish each of these, conversationally:
+   - Customer name, role, ops contact, preferred channel for ops to respond
+   - What artifacts they have (Helm chart? Kustomize? raw manifests? a fragment? nothing yet?)
+   - Whether this represents the prod form or a simplified one
+   - Cloud/platform layer they're on (best-effort; "I don't know" is acceptable)
+   - Customer's k8s comfort level
+   - App success criteria — what running correctly looks like
+
+The success criteria question is the easiest to skip and the most expensive to skip. Establish it during intake; otherwise handoff readiness will hit "no idea what running-correctly means."
+
+### Customer review checkpoint
+
+After horizontal classification, stop. Present the cut — SUT, dep-real, dep-stub, out-of-scope — with one-line reasoning per component. Format so the customer can identify obvious misclassifications without pausing to look things up.
+
+Common pushback shapes:
+
+- "X is in scope because it does Y you didn't see"
+- "Y should be stubbed not real because Z"
+- "Z isn't really used, drop it"
+
+Each correction updates the working file with a reversal entry visible in history. Log a history entry when the customer either confirms the cut or applies corrections — that history entry is what the Self-Review checks.
+
+**Advance to phase 6** (vertical classification) when the customer has confirmed the cut or all corrections have been applied. Set `current_phase: 6` in the working file's frontmatter.
+
+### Stub strategy
+
+For each dependency classified as `Dependency-stub` during horizontal classification, write a *Stub specifications* entry in the working file describing what setup needs to construct. The skill produces descriptions; setup builds the actual stub. Each entry covers:
+
+- **Kind** — what kind of dependency (HTTP service, gRPC service, message queue, database, cloud API, etc.)
+- **Calls the SUT makes against it** — which endpoints, methods, or queue topics; what calls happen during the test flow
+- **Expected response shapes** — what canned responses the stub returns; specific fields the SUT reads
+- **Behaviors required by the test** — success path, specific failure modes, latency characteristics, sequencing
+- **Ordering / sequencing constraints** — if the test depends on a specific order of calls, or on the stub remembering state across calls
+
+Example:
+
+```markdown
+### auth-service (HTTP stub)
+
+**Kind**: External HTTP service
+**Status**: Confirmed
+
+**Calls SUT makes**:
+- `POST /token` (during login flow)
+- `GET /verify?token=<...>` (during request authentication)
+
+**Response shapes**:
+- `POST /token` → `200 OK` with `{"access_token": "<test-jwt>", "expires_in": 3600}`
+- `GET /verify` → `200 OK` with `{"valid": true, "user_id": "<id-from-request>"}` for tokens issued by this stub; `401` for unknown tokens
+
+**Behaviors required**:
+- Stable token issuance — same input produces same token within a test run
+- Failure path: stub should return `401` for verification of an unrecognized token (the test exercises invalid-token handling)
+
+**Ordering / sequencing constraints**: None — each request is independent.
+```
+
+The descriptions are concrete enough for setup to build a stub without needing to re-derive what the SUT expects. They do not prescribe *how* the stub is implemented (Python, Go, mock framework, etc.) — that's setup's call.
+
+**Advance to phase 8** (compile and handoff) when every entry in the *Stub specifications* section has a status of `Confirmed` or `Defaulted` (no `Open`) and every dep-stub from horizontal classification has a corresponding stub spec. Set `current_phase: 8` in the working file's frontmatter.
+
+### Compile and handoff
+
+When `current_phase` is `8`, run the handoff readiness check (see *Working File and Final Report Structure → Handoff readiness checklist*). If it passes, write the final report at `antithesis/scratchbook/k8s-minimization.md` as a snapshot of the working file's *Current state* sections. If it fails, list the gaps to the customer and continue iterating — fixes may require revisiting earlier phases (set `current_phase` back to whichever phase the gap belongs to).
+
+There is no separate customer review checkpoint at compile time. The customer can scan the working file at any pass and push back on any decision; pushback updates the working file with a reversal entry. This is by design — adding a second mandatory checkpoint at compile would slow the loop without proportional benefit, since `Defaulted` decisions are recoverable later when setup runs and behavior is observed. The horizontal review checkpoint (Phase 5) is the only mandatory pause, because horizontal mistakes are the most expensive (vertical work on a misclassified component is wasted effort).
+
+## Working File and Final Report Structure
+
+### Working file: `antithesis/scratchbook/k8s-minimization-work/working.md`
+
+Frontmatter:
+
+```yaml
+---
+current_phase: <integer 1-8 matching the phase the skill should resume in>
+sensitive_data_preference: <"redact-in-place" | "mask" | "share-as-is" | "not-yet-asked">
+started: <YYYY-MM-DD>
+last_pass: <YYYY-MM-DD>
+pass_count: <integer>
+---
+```
+
+Initial values when the working file is created in phase 1: `current_phase: 1`, `sensitive_data_preference: not-yet-asked`, `started` and `last_pass` both set to today's date, `pass_count: 0`. The first regeneration of `ops-questions.md` after intake increments `pass_count` to 1 (see *Skill Flow → pass_count and last_pass semantics* for what counts as a pass).
+
+Body — *Current state* sections:
+
+1. **Header / metadata** — customer info, contact, app name, ops contact, handoff readiness checklist (see below)
+2. **Application overview** — what the app is, what it does, success criteria, SUT identity, test boundary, and *origin* of these (research's `sut-analysis.md` or research-equivalent input from intake)
+3. **Horizontal classification** — SUT, dep-real, dep-stub, out-of-scope, with the inferred call graph and any remaining call-graph open questions. Reverse-dependencies captured *descriptively* (what triggers SUT in prod), not prescriptively. Decisions about test driver design belong to `antithesis-workload`.
+4. **Component inventory** — for each kept component (SUT or dep-real): image + pull info, replicas, env vars and their sources, volume mounts, kept sidecars, dependencies in/out, decisions applied
+5. **Stub specifications** — for each stubbed dependency, what setup needs to fake
+6. **External dependencies (non-stubbed)** — anything outside the cluster the test environment must account for
+7. **Open assumptions** — things defaulted on without confirmation; setup needs to know in case behavior is wrong
+
+Each entry has a status:
+
+- `Confirmed` — known from manifests + customer + ops
+- `Defaulted` — default applied, not yet challenged
+- `Open` — waiting on ops or customer
+
+Body — *History* section: pass-by-pass log. Short entries: what changed in current state, what answers came in, which decisions were reversed and why.
+
+### Final report: `antithesis/scratchbook/k8s-minimization.md`
+
+Generated only when handoff readiness passes. A snapshot of the working file's *Current state* sections (no history, no `Open` items, no live frontmatter beyond a snapshot date). Once setup's k8s support lands, `antithesis-setup` will read this file directly; until then, it is the structured handoff packet the customer shares with their Antithesis engagement team.
+
+If a downstream issue (setup, engagement-team feedback, customer-side discovery) prompts re-entry to this skill and changes are made, regenerate the final report on the next handoff readiness pass — overwriting the prior snapshot. Working file history preserves the audit trail across regenerations.
+
+### Handoff readiness checklist
+
+The skill compiles the final report only when all of these are true:
+
+- All workloads identified
+- Dependencies catalogued (with stub/real classification)
+- Major decisions settled or noted as open assumptions
+- Success criteria captured
+- No unexplained platform leftovers in described components
+- No items with `Open` status remaining (only `Confirmed` and `Defaulted` allowed)
+
+If any item fails, do not write the final report. List the gaps explicitly to the customer and continue iterating.
+
+## Ops-Questions Format
+
+File: `antithesis/scratchbook/k8s-minimization-work/ops-questions.md`. One file at a time, current-pass-only. Resolved questions move to the working file's history; do not let `ops-questions.md` accumulate across passes.
+
+Optimize for: ops engineer opens the doc, replies in 5 minutes, doesn't need a meeting.
+
+Structure:
+
+```markdown
+# Ops Questions — <project name> — Pass <N>
+
+[Brief intro context — use this template, filling in <customer-side-engineer> and
+ <project name>:
+
+  > <customer-side-engineer> here. We're working with Antithesis, a deterministic
+  > testing service that runs our application against a wide range of fault scenarios
+  > and timing conditions to find bugs we'd otherwise miss. To run our system in
+  > Antithesis, we need to minimize our production Kubernetes setup down to a
+  > self-contained test environment, and that needs answers to the questions below.
+  >
+  > Reply by editing this doc inline or pasting into Slack. The worst case is we
+  > make a wrong call and the test setup fails to start — we can fix iteratively.
+  > Your answer doesn't have to be perfect.
+
+If the customer wants to phrase it differently, that's fine — the requirements are:
+two sentences explaining Antithesis, the reply mechanism, and the "answer doesn't
+have to be perfect" framing.]
+
+## Quick context
+
+- What ingress controller do we use? (nginx / traefik / aws-alb / other / none)
+- What's the storage class for PVCs in <namespace>? (default / specific / none)
+- Are there mutating admission webhooks active? (yes / no / don't know)
+[etc. — one-line factual questions ops can answer fast]
+
+## Blocking — we can't proceed without these (or an explicit "don't know")
+
+### Q1: <Specific, scannable title>
+
+**Where**: <file path or kubectl reference>
+
+**Why we're asking**: <one sentence — what decision this affects>
+
+**Pick one**:
+- [ ] <Answer A> → we [action] and proceed
+- [ ] <Answer B> → we [different action]
+- [ ] Don't know → we [default action] and customer team can flag if it breaks verification
+
+[etc.]
+
+## Confirming assumptions
+
+### A1: <Title>
+
+**Assumption**: <what we're assuming and why>
+
+**Push back if**: <what would invalidate the assumption>
+
+[etc.]
+
+## Nice-to-know
+
+- <one-liner>
+- <one-liner>
+```
+
+The "don't know → default action" option is mandatory on every blocking question. Without it, unanswered questions block forever; with it, the worst case is a fixable wrong call.
+
+**The filter on what to ask.** Only ask if the answer changes a decision. If the skill is going to default-drop regardless, do not ask. Every question is a tax on the customer-ops relationship.
+
+**Partial-answer handling.** When ops answers some questions but not others on a round-trip, move the answered questions' substance to the working file's history (capture the answer), then regenerate `ops-questions.md` containing only the still-unanswered questions plus any new ones raised by the answers received. The working file's history is the canonical record of which questions have been answered when.
+
+**Sensitive-data handling.** The intake-time preference (recorded in the working file's frontmatter as `sensitive_data_preference`) governs how `ops-questions.md` content is shaped. When generating questions that quote manifest content, apply the preference: redact in place (replace identifiers with placeholders), mask (use generic names like `<service-name>`), or share as-is. Do not re-prompt the customer at every regeneration — the intake preference is for this audience (the customer's own ops team), and re-prompting becomes friction. Re-prompting only matters when the audience changes (escalation packet → Antithesis engagement team), where the *Sanitization checkpoint* in the escalation section applies.
+
+## Escalation Packet Template
+
+File: `antithesis/scratchbook/k8s-minimization-work/escalation.md`. Generated on demand.
+
+Two triggers:
+
+- Customer asks ("I want to loop in our Antithesis rep")
+- Skill proactively *suggests* (does not auto-generate) when stalling — multiple passes without forward progress, ops unresponsive on blocking questions, customer expressing frustration
+
+Two flavors, same structure:
+
+- **Stalling** — technical work could continue but the human/process side is stuck
+- **Hard problem** — minimization itself has hit something needing Antithesis-side expertise
+
+Structure:
+
+```markdown
+# Antithesis Escalation Packet — <customer> — <YYYY-MM-DD>
+
+## Context
+- Customer: <name, contact>
+- App under test: <brief>
+- Cluster environment: <cloud/platform>
+- Customer-side engineer: <name, role>
+- Antithesis engagement contact (if known): <name>
+
+## Status
+- Currently on pass <N>
+- Started: <YYYY-MM-DD>
+- Most recent activity: <YYYY-MM-DD, what>
+
+## Why we're escalating
+<One paragraph. Specific. Not "we're stuck."
+Example: "Three passes in; ops unresponsive on four blocking Istio AuthZ
+questions; customer engineer unable to get internal traction.">
+
+## Decisions so far
+<Compact summary of the working file's consequential calls.>
+
+## What's open
+<Compact view of ops-questions.md, with how long each has been outstanding.>
+
+## What we've tried
+<For hard-problem escalations specifically. Otherwise omit.>
+
+## Suggested next steps
+<Skill's best guess at what would unstick this. Be honest about confidence — if
+ the skill genuinely doesn't know, say so. "We've exhausted what we can do
+ without ops input" is a valid suggestion.>
+
+## Artifacts
+- working.md
+- ops-questions.md
+- (final report not yet generated; or path if it exists)
+```
+
+**Attaching artifacts.** The packet itself is a single markdown document; the customer should attach the entire `antithesis/scratchbook/k8s-minimization-work/` directory when sending so the engagement team can read the working file directly. Mention this to the customer when generating the packet — don't bake the instruction into the packet body.
+
+**Sanitization checkpoint.** A second sensitive-data prompt (the first is at intake). Even if the customer chose "share as-is" at intake, ask again — different audience (Antithesis engagement team), different stakes. Also scan the packet for obvious patterns (internal hostnames, IP ranges, cloud account IDs, ARNs, embedded credentials, customer-private domains) and prompt the customer to review the whole bundle. Offer to produce a sanitized copy if requested. Customer makes the final call on what gets sent.
+
+**Tone.** Skill writes in its own voice; customer reviews and edits before sending. Neutral and factual, not a complaint. "Here's where we are, here's what's blocking, here's how the rep can help." Should be comfortable to forward without rewriting.
+
+**Snapshot, not evolving.** Each escalation is point-in-time. If escalation is needed again later, generate a fresh one — don't try to maintain a single living escalation document.
+
+## Reference Files
+
+| Reference | When to read |
+| --- | --- |
+| `references/horizontal-classification.md` | Phase 4 — before classifying components into SUT / dep-real / dep-stub / out-of-scope |
+| `references/vertical-classification.md` | Phase 6 — before stripping platform/cloud cruft from kept components |
+| `references/landmines.md` | Phase 6, alongside vertical-classification — for the curated list of common platform constructs and how to handle them; also referenced from horizontal-classification for the *Operators and their products* edge case |
+| `references/operator-recipes.md` | Phase 6, when an operator-replacement decision arises (postgres-operator → primitives, etc.) |
+
+## General Guidance
+
+- The customer's manifests stay where they are. Do not modify or rewrite YAML.
+- Read the working file at the start of every invocation. It is the single source of truth for resumption.
+- Record decisions as they're made, not at the end of a phase. The working file is also the audit trail.
+- When defaulting a decision (no explicit customer or ops input), mark its status as `Defaulted`, not `Confirmed`. The status field is what the handoff readiness check reads.
+- When a customer pushes back on a decision, log the reversal explicitly in the history section. Do not silently rewrite past decisions.
+- Reverse-dependencies (cron jobs, external callers) are captured *descriptively* in the working file ("in prod, X triggers SUT with Y"). The decision about what test drivers exist belongs to `antithesis-workload`. Do not write "test driver needed."
+- Operator-replacement is a horizontal/vertical boundary case. Drop the operator (vertical) but the thing it produces gets its own component entry (horizontal). See `references/operator-recipes.md`.
+
+## Output
+
+- `antithesis/scratchbook/k8s-minimization-work/working.md` (live across passes)
+- `antithesis/scratchbook/k8s-minimization-work/ops-questions.md` (current pass only, regenerated each pass)
+- `antithesis/scratchbook/k8s-minimization-work/escalation.md` (on demand only)
+- `antithesis/scratchbook/k8s-minimization.md` (generated when handoff readiness passes; once setup's k8s support lands, consumed by `antithesis-setup`; until then, the structured handoff packet for the Antithesis engagement team)
+
+## Self-Review
+
+Before declaring this skill complete (writing the final report), review the working file against the criteria below. If your agent supports spawning sub-agents, create a new agent with fresh context to perform this review — give it the path to this skill file and to the working file. A fresh-context reviewer catches blind spots that in-context review misses. If your agent does not support sub-agents, perform the review yourself: re-read the success criteria at the top of this file, then check each criterion below against the working file.
+
+Review criteria:
+
+- The working file's *Application overview* section captures SUT identity, test boundary, success criteria, and the origin (research's `sut-analysis.md` or research-equivalent intake input)
+- Sensitive-data handling preference is recorded in frontmatter (not `not-yet-asked`)
+- Every component visible in the customer's manifests is classified — SUT, dep-real, dep-stub, or out-of-scope — with one-line reasoning
+- The customer reviewed and approved the horizontal classification before vertical work began (the working file's history section contains an entry recording the customer's confirmation or corrections, dated)
+- Every kept component (SUT or dep-real) has a Component inventory entry covering image, replicas, env vars, mounts, kept sidecars, in/out dependencies
+- Every stubbed dependency has a Stub specifications entry describing what setup needs to fake
+- Every `Defaulted` entry has a one-line rationale explaining the default chosen
+- Reverse-dependencies are captured descriptively, not prescriptively — no "test driver needed" language
+- Open assumptions are recorded explicitly, with status `Defaulted` or `Open` — not silently elided
+- No `Open` status items remain in the working file
+- Sensitive-data handling preference was applied to any manifest content quoted in `ops-questions.md` (per the preference recorded in frontmatter)
+- The final report `antithesis/scratchbook/k8s-minimization.md` was written only after handoff readiness passed — it is a snapshot, not a copy of the live working file
+- The final report contains no history section, no live frontmatter beyond a snapshot date, and no `Open` status items (since no `Open` items existed in the working file at the time of snapshot)
+- If escalation was generated, sanitization checkpoints (intake-time and escalation-time) are visible in the working file's history
+- The skill never ran cluster commands; all command execution was the customer's responsibility

--- a/antithesis-k8s-onboarding-assistance/references/horizontal-classification.md
+++ b/antithesis-k8s-onboarding-assistance/references/horizontal-classification.md
@@ -1,0 +1,156 @@
+# Horizontal Classification
+
+## Goal
+
+Classify every component visible in the customer's manifests into one of four categories:
+
+- **SUT** — what's being tested. Run for real. Apply vertical minimization to strip platform/cloud cruft, but the SUT itself keeps functioning.
+- **Dependency — real** — something the SUT calls (or something that calls the SUT) where the test exercises the SUT's behavior in ways that depend on the dependency actually functioning. The dependency runs for real but is itself minimized.
+- **Dependency — stub** — something the SUT calls (or something that calls the SUT) where a fake response from setup is sufficient for the test. The dependency does not run; setup constructs a stub that returns canned answers.
+- **Out of scope** — components in the manifests that aren't part of the SUT or its test-relevant dependencies. Drop entirely.
+
+The "no archaeology" principle applies here twice over: classification is built from research scope plus inferred call graph, and we don't interrogate components that don't show up as connected to the SUT.
+
+## Process
+
+Six steps. Customer review (the next phase) follows this; do not advance to vertical until it has passed.
+
+### 1. Identify the SUT
+
+Read `antithesis/scratchbook/sut-analysis.md` (or the research-equivalent input captured in the working file's *Application overview*). Map the named SUT components to manifest entries.
+
+If the SUT named in research doesn't obviously map to a single manifest component, ask the customer once which manifest entry corresponds. Record the mapping in the working file.
+
+### 2. Build a call graph from the manifests
+
+Three confidence tiers. Document edges by tier in the working file's *Horizontal classification* section.
+
+**High confidence — direct evidence:**
+
+- `Service` definitions and the workloads selecting them (selector → labels)
+- Env vars containing service references (e.g., `DB_HOST=postgres.svc.cluster.local`, `AUTH_API_URL=auth-service:8080/api`)
+- ConfigMap entries that reference services
+- Init container `wait-for` style dependencies (often invoke `nslookup`, `nc`, or shell scripts naming services)
+- PVC claims and the StorageClass they reference
+- Sidecar references in pod specs (Istio `proxy`, `vault-agent-injector`, etc.)
+
+**Lower confidence — inferred:**
+
+- Naming conventions (e.g., `frontend` → `backend` → `db` follows a typical pattern)
+- NetworkPolicy `allow` rules (when present, they often reveal intended traffic)
+- Secret references suggesting auth to a known service
+- Service mesh routing rules (Istio `VirtualService`, `DestinationRule`)
+
+**Cannot be inferred from manifests — ask:**
+
+- Async messaging (queues, pub/sub, event buses)
+- Indirect dependencies through shared databases (write/read patterns)
+- Hardcoded URLs baked into container images
+- Scheduled jobs that touch the SUT
+- Backend services hit through shared API gateways
+
+For non-inferable interactions, generate exactly one structural ops-question in `ops-questions.md` using the standard *Blocking* question schema:
+
+```markdown
+### Q<n>: Are there interactions involving the SUT we can't see from the manifests?
+
+**Where**: <SUT manifest references>
+
+**Why we're asking**: From the manifests, the SUT calls <list of A, B, ...>. We want to know if there are other interactions we can't see — async messaging via queues, scheduled jobs that trigger the SUT, indirect dependencies through shared databases or caches, or anything else where the SUT participates without it being visible in service refs/env vars/etc.
+
+**Pick one**:
+- [ ] No — the manifests show all the interactions; nothing else touches the SUT during the tested flow → we proceed with the current classification
+- [ ] Yes, here are the others: <ops fills in> → we promote those components from out-of-scope into Dependency candidates and re-classify
+- [ ] Don't know → we proceed assuming the manifests are complete; we'll catch missing interactions during setup or at runtime if they break things
+```
+
+Don't fragment this into one question per suspected channel. One structural question is enough; the answer either confirms the inferred call graph or promotes out-of-scope components to in-scope.
+
+### 3. Classify by reachability from SUT
+
+For each component:
+
+- Direct dep (SUT calls it, or it calls the SUT during the test flow) → *Dependency* candidate
+- Transitive dep (something the SUT's direct deps call, but the SUT doesn't touch) → *Out of scope*, default
+- No path to SUT in the inferred graph → *Out of scope*
+
+When in doubt, drop. The customer review checkpoint catches false drops; aggressive cuts are cheap to revert.
+
+### 4. Decide stub vs. real for dependencies
+
+Default heuristics. Apply unless the customer explicitly overrides.
+
+- **Database** → run real. Databases are usually testable in isolation, often what's being exercised, and stubbing them is more work than running a real instance.
+- **Microservice** → stub. Less work than running real, often sufficient for the SUT's behavior under test.
+- **Cloud-managed service (e.g., AWS Secrets Manager, GCP Pub/Sub)** → stub. No choice — can't run cloud locally.
+- **Message queue / streaming platform (Kafka, RabbitMQ)** → run real. Stubs can't easily reproduce the behaviors that matter (ordering, partitioning, consumer groups). Use a lightweight protocol-compatible alternative if available (Redpanda for Kafka).
+- Customer says "we want to test integration with X" → run real
+- Customer says "X is just a downstream we call" → stub
+
+If the heuristic conflicts with the customer's explicit input, the customer wins. Record the override in the working file.
+
+### 5. Identify call-graph gaps
+
+Any component whose classification depends on a non-inferable interaction (item 2's "ask" tier) gets flagged as `Open` until ops answers the structural question. Don't promote `Open` to `Defaulted` here; defaults apply to things we *could* infer but chose to act on. `Open` means "we genuinely don't know."
+
+### 6. Record in the working file
+
+Write the classification to the *Horizontal classification* section of `working.md`. For each component:
+
+```markdown
+- **<component-name>** — <SUT | Dependency-real | Dependency-stub | Out-of-scope>
+  - Status: <Confirmed | Defaulted | Open>
+  - Reasoning: <one or two sentences of why>
+```
+
+Update `current_phase` in frontmatter to `5` (the customer review checkpoint phase). The customer review is its own phase; don't combine it with horizontal classification.
+
+## Edge Cases
+
+### Transitive chains: SUT → A → B → C
+
+Default: `A` is dep, `B` and `C` are out-of-scope.
+
+Reasoning: if `A` is stubbed, the stub returns canned data and `B`/`C` are never called. If `A` is real, `B`/`C` might be called but aren't being tested — exercising them isn't the goal.
+
+Override: customer says "we want to test the full chain end-to-end." Then `B` and `C` become deps too. Record the override and the customer's reason.
+
+### Shared infrastructure (database, queue, cache used by multiple services)
+
+Common pattern: SUT and another service both write to and read from the same database, but the test only cares about the SUT's behavior.
+
+Default: pre-populate test data the SUT needs, drop the writer service. Setup constructs initial state; the SUT runs against it without the writer being live.
+
+Override: customer wants producer/consumer integration in the test (e.g., they're testing how SUT reacts to data the writer produces). Then the writer becomes a dep too — usually run-real, sometimes stubbed.
+
+### Reverse dependencies (things that call the SUT)
+
+Examples: cron jobs that trigger the SUT every minute, controllers from other services that issue commands to the SUT, monitoring health-checkers.
+
+Capture these *descriptively*: what triggers the SUT in prod, with what shape of input, on what schedule. Record under *Horizontal classification → Reverse dependencies (descriptive)* in the working file. Example entry:
+
+```markdown
+- **order-trigger-cron**
+  - Triggers SUT in prod via: HTTP POST to `/orders` every minute
+  - Payload shape: `{order_id: <uuid>, items: <list>}`
+  - Status: Confirmed (verified from CronJob spec)
+```
+
+Do not write "test driver needed: cron-style every minute." That decision belongs to `antithesis-workload`, which reads this descriptive information and designs drivers against the property catalog. Workload may end up making something very different from the prod cron — flooded inputs, malformed data, fault-injected scenarios. The prod pattern is a fact, not a prescription.
+
+### Operators and their products
+
+A common pattern: the customer uses an operator (e.g., `postgres-operator`, `redis-operator`, `strimzi-kafka`) that watches a CR and creates the actual workload. The operator itself is platform machinery; the workload it creates may be SUT-critical.
+
+Classification:
+
+- The operator → vertical-platform-cruft, drop (handled in vertical classification)
+- The thing the operator produces → its own component entry, classified normally (typically dep-real if it's a database)
+
+In the working file's *Component inventory*, the operator-produced thing should be described in primitives terms (StatefulSet, Service, ConfigMap, etc.) rather than as a CR. The recipe for converting comes from `references/operator-recipes.md`. Phase 6 (vertical classification) handles the actual conversion; phase 4 only needs to flag that the operator-produced component exists and what its role is.
+
+## Output
+
+Working file *Horizontal classification* section, fully populated, with status fields per component. The structural ops-question (if needed) is in `ops-questions.md`. `current_phase` is set to `5`.
+
+Customer review checkpoint follows. Do not advance to vertical classification before that phase has passed.

--- a/antithesis-k8s-onboarding-assistance/references/landmines.md
+++ b/antithesis-k8s-onboarding-assistance/references/landmines.md
@@ -1,0 +1,241 @@
+# Landmines
+
+Curated list of common platform constructs encountered during k8s minimization. Each entry follows the schema below. Entries are grouped by category, not ordered by frequency — easier to add new entries as engagements surface them.
+
+## Entry Schema
+
+Every entry has these fields:
+
+- **Recognition signals** — manifest patterns indicating the construct is present (CR kinds, annotations, labels, container names, namespace patterns)
+- **Default action** — `drop` / `simplify` / `replace-with-equivalent` / `replace-with-primitives`
+- **Working file rationale** — one-line explanation in customer-readable language, recorded when the decision is made
+- **Fidelity impact** — what behavior changes when the default is applied; which kinds of apps actually feel it
+- **Override recipe** — if the customer wants to keep it, concrete steps for setup
+- **Calibration question (optional)** — asked of the customer (not ops), only if the answer would change the default
+- **Confidence factors** — signals that bump confidence in the default. Low confidence triggers the calibration question; high confidence applies the default silently.
+
+When a landmine doesn't have a calibration question, apply its default action without asking the customer. When a landmine has a calibration question, ask it only when the *Confidence factors* indicate confidence is low; otherwise apply the default silently.
+
+---
+
+## Service Mesh
+
+### Istio
+
+- **Recognition signals**:
+  - Sidecar container `istio-proxy` in pod specs
+  - Namespace label `istio-injection: enabled`
+  - Pod annotation `sidecar.istio.io/inject: "true"`
+  - Resources of kind `VirtualService`, `DestinationRule`, `Gateway`, `ServiceEntry`, `PeerAuthentication`, `AuthorizationPolicy`, `RequestAuthentication`
+  - Namespace `istio-system`
+- **Default action**: `drop`. Remove Istio CRs, strip injection labels and annotations, drop `istio-proxy` sidecars from pod specs.
+- **Working file rationale**: "Dropped Istio mesh — pod-to-pod via direct Service DNS in single-node test env."
+- **Fidelity impact**: Diverges if the app relies on mTLS workload identity for service-to-service AuthZ, Istio-level retries/timeouts, traffic splitting, fault injection used in tests, or Istio-emitted telemetry the app depends on. Most apps don't notice; some do.
+- **Override recipe**: Install Istio in the test environment (`istioctl install --set profile=demo` or via Helm), re-add `istio-injection: enabled` on the SUT namespace, accept ~30–60s of extra pod startup. Note: Antithesis's deterministic single-node environment may interact unusually with Istio's distributed-system features (retries, circuit breakers).
+- **Calibration question**: "Does your app's correctness depend on Istio behavior — workload identity for service-to-service AuthZ, retry/timeout policies, or traffic splitting? If unsure, the safer choice is to keep Istio."
+- **Confidence factors**:
+  - High confidence in `drop` if only injection is configured and no `AuthorizationPolicy`, `RequestAuthentication`, or `PeerAuthentication` resources exist
+  - Lower confidence (ask the calibration question) if any of those AuthZ/AuthN resources are present, since the app likely depends on Istio for AuthZ
+
+### Linkerd
+
+- **Recognition signals**:
+  - Sidecar container `linkerd-proxy` in pod specs
+  - Pod annotation `linkerd.io/inject: enabled`
+  - Resources of kind `ServiceProfile`, `TrafficSplit`
+  - Namespace `linkerd`
+- **Default action**: `drop`. Strip injection annotations and `linkerd-proxy` sidecars, drop Linkerd CRs.
+- **Working file rationale**: "Dropped Linkerd mesh — direct pod-to-pod in single-node test env."
+- **Fidelity impact**: Diverges if app relies on mTLS, Linkerd-level retries, or `TrafficSplit`-driven canary testing. Less common than Istio dependence; usually safe.
+- **Override recipe**: Install Linkerd in the test environment, re-add the inject annotation. Accept startup overhead.
+- **Calibration question**: "Does your app behavior depend on Linkerd retries, traffic splitting, or mTLS identity? If unsure, drop and we'll add it back if we hit issues."
+- **Confidence factors**: High confidence in `drop` unless `TrafficSplit` resources are present.
+
+---
+
+## Certificate Management
+
+### cert-manager
+
+- **Recognition signals**:
+  - Resources of kind `Certificate`, `Issuer`, `ClusterIssuer`, `CertificateRequest`
+  - Annotations `cert-manager.io/cluster-issuer`, `cert-manager.io/issuer`
+  - Namespace `cert-manager`
+- **Default action**: `drop`. Drop all cert-manager CRs, strip cert-manager annotations from `Ingress` resources. For `Secret` resources that cert-manager would have populated with TLS material, replace with a self-signed cert generated at startup or hand-baked into the manifest.
+- **Working file rationale**: "Dropped cert-manager — TLS not material to test scope; self-signed substitute if internal TLS needed."
+- **Fidelity impact**: Negligible for most apps. Diverges only if app inspects cert metadata, depends on rotation behavior, or has logic conditional on the issuing authority.
+- **Override recipe**: Install cert-manager in the test environment (`kubectl apply -f https://github.com/cert-manager/cert-manager/releases/...`), use a self-signed `ClusterIssuer` instead of Let's Encrypt or any cloud issuer, accept ~30s startup.
+- **Calibration question**: Usually skip. Ask only if the working file's *Application overview* mentions cert-related behavior (rotation testing, etc.).
+- **Confidence factors**: High confidence in `drop` for typical web apps that use TLS via ingress.
+
+---
+
+## Secrets
+
+### External Secrets Operator
+
+- **Recognition signals**:
+  - Resources of kind `ExternalSecret`, `SecretStore`, `ClusterSecretStore`
+  - Namespace `external-secrets`
+- **Default action**: `replace-with-equivalent`. For each `ExternalSecret`, create a plain `Secret` with test values (customer provides values, or skill generates placeholders for non-sensitive items). Drop `SecretStore` and the operator itself.
+- **Working file rationale**: "Replaced N ExternalSecret resources with plain Secrets containing test values."
+- **Fidelity impact**: None. The app sees `Secret` resources either way; the only difference is how they're populated, which is invisible to the app.
+- **Override recipe**: Customer would not usually want to keep ESO — its purpose is to source from cloud secret stores, which we can't reach. Skip override.
+- **Calibration question**: "For each of these N secrets, can you provide test values? Some need real-looking values for the app to function (database connection strings, etc.) and some don't (API keys for services we're stubbing). Walk through them with me."
+- **Confidence factors**: This is more a workflow question than a confidence question. The replacement is mechanical; the inputs are what need customer involvement.
+
+### Sealed Secrets
+
+- **Recognition signals**:
+  - Resources of kind `SealedSecret`
+  - Controller namespace `sealed-secrets`
+- **Default action**: `replace-with-equivalent`. Replace each `SealedSecret` with a plain `Secret` containing test values. Drop the controller.
+- **Working file rationale**: "Replaced N SealedSecret resources with plain Secrets — encrypted-at-rest is not a concern for the test environment."
+- **Fidelity impact**: None. The decrypted secret is what the app sees in either case.
+- **Override recipe**: Skip override — sealed-secrets exists to gate prod-secret distribution; no purpose in test.
+- **Calibration question**: Same workflow question as ExternalSecret — what test values for each.
+- **Confidence factors**: High confidence in replacement.
+
+---
+
+## DNS
+
+### external-dns
+
+- **Recognition signals**:
+  - Annotations `external-dns.alpha.kubernetes.io/hostname`, `external-dns.alpha.kubernetes.io/target` on `Service` or `Ingress` resources
+  - Deployment named `external-dns` in namespace `external-dns` or `kube-system`
+- **Default action**: `drop`. Drop the operator and strip the annotations from `Service`/`Ingress` resources. The app resolves dependencies by Service DNS within the cluster.
+- **Working file rationale**: "Dropped external-dns — internal Service DNS handles intra-cluster resolution."
+- **Fidelity impact**: Diverges only if the app has logic that depends on resolving its own external DNS name (rare; usually behind a CDN or load balancer in prod).
+- **Override recipe**: No useful override — external-dns updates real DNS providers, which the test environment can't reach.
+- **Calibration question**: None.
+- **Confidence factors**: High confidence in `drop`.
+
+---
+
+## Networking
+
+### NetworkPolicy
+
+- **Recognition signals**:
+  - Resources of kind `NetworkPolicy`
+- **Default action**: `drop`. NetworkPolicies are CNI-enforced; in single-node Antithesis test env there's no CNI doing the enforcement.
+- **Working file rationale**: "Dropped NetworkPolicy — no CNI enforcement in single-node test env."
+- **Fidelity impact**: Diverges if the app's correctness depends on enforcement (e.g., a property "service A cannot reach service B" that's tested by checking enforcement). Unusual.
+- **Override recipe**: No useful override in single-node setups.
+- **Calibration question**: None.
+- **Confidence factors**: High confidence in `drop`.
+
+### Cloud LoadBalancer / NodePort Services
+
+- **Recognition signals**:
+  - `Service` of `type: LoadBalancer`
+  - `Service` of `type: NodePort`
+  - Cloud-provider-specific `Service` annotations (`service.beta.kubernetes.io/aws-load-balancer-*`, `cloud.google.com/load-balancer-type`, etc.)
+- **Default action**: `simplify` to `type: ClusterIP`. Strip cloud-provider annotations.
+- **Working file rationale**: "Simplified Service from LoadBalancer to ClusterIP — internal access only in test env."
+- **Fidelity impact**: Diverges if the app depends on external access patterns (idle connection draining, SNI routing on a cloud LB). Setup configures port-forwarding for any external test access needed.
+- **Override recipe**: Run a real load balancer in the test env (MetalLB on k3s, or a sidecar like envoy). Most tests don't need this; setup defaults to port-forward.
+- **Calibration question**: None.
+- **Confidence factors**: High confidence in `simplify`.
+
+### Cloud-specific Ingress
+
+- **Recognition signals**:
+  - `Ingress` with `ingressClassName: alb` / `gce` / equivalent
+  - Annotations like `alb.ingress.kubernetes.io/*`, `nginx.ingress.kubernetes.io/...`
+- **Default action**: `drop` (preferred — port-forward to the SUT in test env) or `simplify` to a generic `nginx` ingress in test env if URL routing matters for the test.
+- **Working file rationale**: "Dropped cloud-managed Ingress — port-forward to SUT in test env."
+- **Fidelity impact**: Diverges if app depends on path-based routing, header rewriting, or other ingress-level logic that affects what the SUT sees. Surface the customer's ingress rules; ask if any of them change request shape.
+- **Override recipe**: Install nginx-ingress (or whichever class) in the test env, replicate the routing rules without cloud-provider annotations.
+- **Calibration question**: "Does any of your ingress configuration rewrite headers, paths, or redirect requests in ways the SUT depends on?"
+- **Confidence factors**: High confidence in `drop` if Ingress only routes to a single Service. Lower confidence if Ingress has rewrite, redirect, or auth annotations.
+
+---
+
+## Cloud IAM
+
+### AWS IRSA / GCP Workload Identity / Azure AD Workload Identity
+
+- **Recognition signals**:
+  - `ServiceAccount` annotations: `eks.amazonaws.com/role-arn` (AWS), `iam.gke.io/gcp-service-account` (GCP), `azure.workload.identity/client-id` (Azure)
+  - Pod annotations referencing workload identity
+- **Default action**: `drop` annotations. The test env uses static credentials provided by setup or stubs cloud calls entirely.
+- **Working file rationale**: "Dropped IRSA / Workload Identity annotations — test env uses static creds for stubbed cloud services."
+- **Fidelity impact**: The app can no longer reach real cloud services using a workload identity. This is fine because cloud services are stubbed during horizontal classification anyway.
+- **Override recipe**: Customer provides test-environment AWS access keys, GCP service account JSON, or Azure principal credentials, mounted as Secrets. This only matters if a cloud service was classified as dep-real (rare).
+- **Calibration question**: None — usually flowed from the horizontal stub-vs-real decisions.
+- **Confidence factors**: High confidence in `drop` when cloud services are stubbed.
+
+---
+
+## Autoscaling and Reliability Constraints
+
+### HorizontalPodAutoscaler / VerticalPodAutoscaler
+
+- **Recognition signals**: Resources of kind `HorizontalPodAutoscaler`, `VerticalPodAutoscaler`
+- **Default action**: `drop`. Single-node test env scales nothing.
+- **Working file rationale**: "Dropped HPA/VPA — fixed replica count in test env."
+- **Fidelity impact**: None unless the test specifically exercises autoscaling behavior (rare).
+- **Override recipe**: Not applicable; single-node.
+- **Calibration question**: None.
+- **Confidence factors**: High confidence in `drop`.
+
+### PodDisruptionBudget
+
+- **Recognition signals**: Resources of kind `PodDisruptionBudget`
+- **Default action**: `drop`. Voluntary disruptions don't apply in single-node test env.
+- **Working file rationale**: "Dropped PDB — no voluntary eviction in single-node test env."
+- **Fidelity impact**: None.
+- **Override recipe**: Not applicable.
+- **Calibration question**: None.
+- **Confidence factors**: High confidence.
+
+### ResourceQuota / LimitRange
+
+- **Recognition signals**: Resources of kind `ResourceQuota`, `LimitRange`
+- **Default action**: `drop`. Test env has no namespace-level quota enforcement.
+- **Working file rationale**: "Dropped ResourceQuota/LimitRange — test env relies on per-pod resource requests/limits."
+- **Fidelity impact**: None unless the app depends on being throttled by quota (very rare).
+- **Override recipe**: Not applicable.
+- **Calibration question**: None.
+- **Confidence factors**: High confidence.
+
+---
+
+## Observability
+
+### Observability Sidecars
+
+- **Recognition signals**: Sidecar containers named `datadog-agent`, `fluent-bit`, `fluentd`, `otel-collector`, `splunk-forwarder`, `jaeger-agent`, `vector`, `filebeat`, etc.
+- **Default action**: `drop` from pod specs. Antithesis has its own observability.
+- **Working file rationale**: "Dropped <sidecar> sidecar — Antithesis provides observability."
+- **Fidelity impact**: None unless the app has logic conditional on log forwarding (extremely rare).
+- **Override recipe**: Not applicable.
+- **Calibration question**: None.
+- **Confidence factors**: High confidence in `drop`.
+
+### ServiceMonitor / PodMonitor (Prometheus operator)
+
+- **Recognition signals**: Resources of kind `ServiceMonitor`, `PodMonitor`, `PrometheusRule`
+- **Default action**: `drop`.
+- **Working file rationale**: "Dropped Prometheus operator CRs — Antithesis observability replaces."
+- **Fidelity impact**: None.
+- **Override recipe**: Not applicable.
+- **Calibration question**: None.
+- **Confidence factors**: High confidence.
+
+---
+
+## Generic CRD or Operator (Catch-all)
+
+When you encounter a Custom Resource or operator that doesn't match any entry above, treat it as a generic landmine.
+
+- **Recognition signals**: A CR with a group/kind not explicitly handled elsewhere; an operator Deployment whose role isn't immediately obvious.
+- **Default action**: `drop`. Drop both the CR and (if present in the customer's manifests) the CRD definition. If the operator produces a workload that the SUT depends on, see `references/operator-recipes.md` for the replace-with-primitives pattern.
+- **Working file rationale**: "Dropped <CR/operator> — unrecognized platform construct; flag if app relies on it."
+- **Fidelity impact**: Unknown. Customer pushback at the customer review checkpoint or at handoff is the correction mechanism.
+- **Override recipe**: Customer states the role of the operator and how the app depends on it. If the answer is "the operator provides a runtime service the SUT calls," classify the produced workload using `references/operator-recipes.md`. If the answer is "platform-only, the SUT doesn't depend on it," confirm `drop`.
+- **Calibration question**: "I don't recognize this CRD/operator. Briefly: what does it do, and does the SUT depend on its presence at runtime?"
+- **Confidence factors**: Low confidence by default. Always ask the calibration question for unknown operators.

--- a/antithesis-k8s-onboarding-assistance/references/operator-recipes.md
+++ b/antithesis-k8s-onboarding-assistance/references/operator-recipes.md
@@ -1,0 +1,134 @@
+# Operator-Replacement Recipes
+
+When an operator produces a workload the SUT depends on (e.g., `postgres-operator` creating a Postgres instance, `strimzi` creating a Kafka cluster), the operator itself is platform machinery and should be dropped — but the workload it produced needs to be described in the report so setup can construct it.
+
+These recipes describe what primitives to specify in the working file's *Component inventory* in place of the operator-managed CR.
+
+## Recipe Schema
+
+Each recipe describes:
+
+- **Operator family** — which operators this recipe applies to
+- **CR signals** — what the operator-managed Custom Resource looks like
+- **Replacement primitives** — what the customer's component entry should describe instead of the CR
+- **Test-environment simplifications** — replica reductions, single-instance modes, etc.
+- **Common configuration to extract from the CR** — fields in the CR that should map to the replacement
+- **Caveats** — known divergences from the operator's typical setup
+
+## Initial Recipes
+
+This file ships with one worked recipe: Postgres. Redis, Kafka, MongoDB, Elasticsearch, and others are deferred to follow-up engagements as the patterns are refined. When you encounter an operator without a recipe here, work the customer through the structure described in *Recipe Schema* and add a draft entry to a follow-up issue.
+
+---
+
+### Postgres (Zalando, CrunchyData, CloudNativePG, percona-postgresql-operator)
+
+**Operator family**: `postgres-operator` (Zalando), `postgres-operator` (CrunchyData/PGO), `cnpg-controller-manager` (CloudNativePG), `percona-postgresql-operator`.
+
+**CR signals**:
+
+- `postgresql.cnpg.io/Cluster` (CloudNativePG)
+- `acid.zalan.do/postgresql` (Zalando)
+- `postgres-operator.crunchydata.com/PostgresCluster` (CrunchyData)
+- `pg.percona.com/PerconaPGCluster` (Percona Operator for PostgreSQL v1) or `pgv2.percona.com/PerconaPGCluster` (v2)
+
+The CR fields differ between operators but the underlying concept is the same: a managed Postgres instance with replicas, storage, configuration, backups, and monitoring.
+
+**Replacement primitives** (component inventory entry):
+
+```markdown
+### postgres (StatefulSet)
+
+**Scope**: Dependency-real
+**Status**: Defaulted (operator-replacement applied; flag if the app needs operator-specific behavior)
+
+**Image**: postgres:<major-version>-alpine (matching prod major version; use official image)
+
+**Replicas**: 1 (simplified from prod's <N>; test exercises a single-instance Postgres)
+
+**Env vars**:
+- `POSTGRES_USER` — from Secret `postgres-credentials` (test value)
+- `POSTGRES_PASSWORD` — from Secret `postgres-credentials` (test value)
+- `POSTGRES_DB` — value from CR's `databases:` section
+- `PGDATA` — `/var/lib/postgresql/data/pgdata`
+
+**Volume mounts**:
+- `/var/lib/postgresql/data` ← PVC `postgres-data` (size from CR; minimum 1Gi)
+- `/etc/postgresql/postgresql.conf` ← ConfigMap `postgres-config` (extracted from CR's `postgresql.parameters`)
+
+**Sidecars (kept)**:
+- (none — operator-injected sidecars for backup/monitoring are platform; drop)
+
+**Sidecars (dropped)**:
+- `pgbackrest` / `wal-g` — backup sidecars; not needed in test env
+- `postgres-exporter` — metrics; Antithesis observability replaces
+
+**Dependencies in**:
+- <SUT names>
+
+**Dependencies out**:
+- (none; standalone)
+
+**Decisions applied**:
+- Replaced operator-managed CR with hand-rolled StatefulSet + Service + ConfigMap + PVC + Secret
+- Reduced replicas from <N> to 1 (single-instance Postgres for test)
+- Dropped pgbackrest sidecar — backup not relevant in test env
+- Dropped postgres-exporter sidecar — Antithesis observability
+- Test values for credentials (customer provides actual values via setup)
+```
+
+Plus a Service:
+
+```markdown
+### postgres-service (Service)
+
+ClusterIP service exposing port 5432, selector matching the StatefulSet.
+Decisions applied: standard ClusterIP for in-cluster access from SUT.
+```
+
+**Test-environment simplifications**:
+
+- Replicas: prod-N → 1
+- Backup, archiving, WAL shipping: drop
+- Monitoring sidecars: drop
+- High availability (synchronous replication, primary/replica): drop — single instance
+- Connection pooling sidecar (pgbouncer) often part of CR: keep only if SUT addresses it directly (i.e., SUT connects to `pgbouncer` rather than `postgres`); otherwise drop
+
+**Common configuration to extract from the CR**:
+
+| CR field (varies by operator) | Replacement target |
+| --- | --- |
+| `postgres.version` / `postgresql.version` | StatefulSet image tag |
+| `databases:` / `users:` | `POSTGRES_DB` / `POSTGRES_USER` env, plus init SQL if multiple databases |
+| `volume.size` / `storage.size` | PVC size |
+| `postgresql.parameters` / `parameters` | ConfigMap `postgresql.conf` content |
+| `tls:` configuration | Drop in test env unless SUT requires TLS to its DB |
+| `backup:` block | Drop |
+| `monitoring:` / `metrics:` block | Drop |
+| `numberOfInstances` / `instances` / `replicas` | Force to 1 in test |
+
+**Caveats**:
+
+- If the SUT's Postgres connection uses operator-injected service discovery (e.g., a `postgres-cluster.namespace.svc.cluster.local` hostname created by the operator), the replacement Service name must match what the SUT expects. Verify the SUT's `DB_HOST` env var (or equivalent) and name the replacement Service accordingly.
+- Some operators provide a "writer" service and a "reader" service for primary/replica routing. With single-instance replacement, both names should resolve to the same Service. Either alias them or update the SUT's configuration to use one name.
+- If the SUT relies on logical replication, change-data-capture (CDC), or other features that require specific Postgres extensions or `wal_level=logical`, those settings need to be in the replacement ConfigMap.
+- If the customer's CR specifies a non-default Postgres major version, the replacement image tag should match. Compatibility issues at minor-version differences are usually fine; major-version mismatches can cause behavior changes.
+
+---
+
+## Adding New Recipes
+
+When you encounter an operator without a recipe here:
+
+1. Apply the *Generic CRD or operator* landmine entry as the immediate default.
+2. Walk the customer through the *Recipe Schema* fields above to capture what the operator-managed thing is, what primitives could replace it, and what test-environment simplifications make sense.
+3. Record the resulting component description in the working file under *Component inventory* for the produced workload.
+4. After the engagement, contribute a draft recipe entry to this file in a follow-up PR. Each engagement adds to the curated list.
+
+Common candidates for future recipes:
+
+- Redis (`redis-operator`, `RedisFailover`, `RedisCluster`)
+- Kafka (`kafka.strimzi.io/Kafka`, `platform.confluent.io/Kafka`)
+- MongoDB (`psmdb.percona.com/PerconaServerMongoDB`, `mongodbcommunity.mongodb.com/MongoDBCommunity`)
+- Elasticsearch (`elasticsearch.k8s.elastic.co/Elasticsearch`)
+- RabbitMQ (`rabbitmq.com/RabbitmqCluster`)

--- a/antithesis-k8s-onboarding-assistance/references/vertical-classification.md
+++ b/antithesis-k8s-onboarding-assistance/references/vertical-classification.md
@@ -1,0 +1,145 @@
+# Vertical Classification
+
+## Goal
+
+For each component that survived horizontal classification (SUT or dep-real), strip platform/cloud/observability cruft. The output is a description of what the component looks like *after* minimization — what should be kept, what should be dropped, and what should be replaced.
+
+This skill produces descriptions, not YAML. Vertical classification populates the *Component inventory* section of the working file with structured per-component entries that `antithesis-setup` later materializes.
+
+## Framework
+
+Two internal axes drive each per-resource decision:
+
+**Origin** — what is this resource's purpose?
+
+- **App** — belongs to the customer's application
+- **Platform** — provided by the cluster's platform layer (mesh, ingress controller, secret operators, etc.)
+- **Cloud** — cloud-provider-specific (LoadBalancer types, IAM annotations, cloud storage classes)
+- **Observability** — monitoring, logging, tracing
+- **Security/Policy** — admission policies, NetworkPolicies, PodDisruptionBudgets
+- **Unclear**
+
+**Necessity** — does the app need this to function?
+
+- **Required** — won't run without it
+- **Replaceable** — needed conceptually; a local equivalent exists
+- **Optional** — degrades gracefully without it
+- **Irrelevant** — not needed at all
+
+## Decision Matrix
+
+| Origin | Default action |
+| --- | --- |
+| App + Required | Keep |
+| App + Replaceable | Simplify (LoadBalancer → ClusterIP, real PVC → emptyDir for stateless, etc.) |
+| Platform | Drop |
+| Cloud + Required | Replace with local equivalent |
+| Cloud + Optional | Drop |
+| Observability | Drop (Antithesis has its own observability) |
+| Security/Policy | Drop (single-node, deterministic env) |
+| Unclear | Drop unless referenced by something we're keeping |
+
+The "Unclear → drop" default is what makes "no archaeology" work in practice. If the customer wants to keep something Unclear, they can override at customer review.
+
+## Method, Not Encyclopedia
+
+Don't try to enumerate every k8s construct. Most cases are obvious:
+
+- `DaemonSet` whose image is a log shipper, agent, or CNI component → Platform → drop
+- `NetworkPolicy` → Security/Policy → drop (no enforcement in single-node)
+- `HorizontalPodAutoscaler`, `VerticalPodAutoscaler` → Security/Policy → drop
+- `PodDisruptionBudget`, `ResourceQuota`, `LimitRange` → Security/Policy → drop
+- `Service` of type `LoadBalancer` → App + Replaceable → simplify to `ClusterIP`
+- `Service` of type `NodePort` → App + Replaceable → simplify to `ClusterIP` unless test needs external access
+- `Ingress` with cloud-specific annotations (ALB, GCE) → Cloud → drop or simplify
+- `ServiceMonitor`, `PodMonitor` → Observability → drop
+- `Job` / `CronJob` whose name and image suggest the customer's app → App, classify by scope
+- `Job` / `CronJob` for backups, log rotation, or platform tasks → Platform → drop
+
+For the non-obvious cases — Antithesis-specific landmines with known recipes — read `references/landmines.md`. For operator-produced workloads where the operator itself is being dropped, read `references/operator-recipes.md`.
+
+## Process
+
+Five steps for each pass through vertical classification:
+
+1. **Scan for operator-flagged components from horizontal.** Before applying the decision matrix to anything, look at the working file's *Horizontal classification* section for any operator-produced components flagged during phase 4 (e.g., a Postgres CR managed by an operator). For each, apply the matching recipe from `references/operator-recipes.md` to expand the CR into primitives in *Component inventory*. The operator itself is dropped via the matrix (Platform → drop); the produced workload becomes its own component entry to classify normally.
+
+2. **Iterate over kept components.** For each component classified as SUT or dep-real, apply the Origin × Necessity framework. Use the curated landmines (`references/landmines.md`) for known constructs; rely on Claude's general k8s knowledge for routine ones.
+
+3. **Surface fidelity tradeoffs.** When applying a default with meaningful fidelity impact, state the fidelity cost and the override path to the customer. See *Defaults Are Defaults* below for when this matters.
+
+4. **Generate calibration questions when confidence is low.** Each landmine entry's *Confidence factors* tell you when to ask the calibration question. Add any calibration questions to `ops-questions.md`.
+
+5. **Record per-component output.** Populate *Component inventory* in the working file using the schema in *Per-Component Output* below.
+
+When all kept components have entries, advance `current_phase` to `7` (stub strategy).
+
+## Per-Component Output
+
+Populate the working file's *Component inventory* section. For each kept component:
+
+```markdown
+### <component-name> (<Deployment | StatefulSet | DaemonSet | etc.>)
+
+**Scope**: <SUT | Dependency-real>
+**Status**: <Confirmed | Defaulted | Open>
+
+**Image**: <registry/image:tag> (<public | private; pull constraints if any>)
+
+**Replicas**: <number in prod> → <number in test, with reason if simplified>
+
+**Env vars**:
+- `KEY1` — <value or source: ConfigMap, Secret, downward API>
+- `KEY2` — <value or source>
+
+**Volume mounts**:
+- <path> ← <source: ConfigMap, Secret, PVC, emptyDir>
+
+**Sidecars (kept)**:
+- <name> — <reason kept>
+
+**Sidecars (dropped)**:
+- <name> — <landmine reference, e.g., "istio-proxy (see landmines.md → service mesh)">
+
+**Dependencies in**:
+- <what calls this component>
+
+**Dependencies out**:
+- <what this component calls>
+
+**Decisions applied**:
+- Kept: <list>
+- Simplified: <list with before → after, e.g., "Service type LoadBalancer → ClusterIP">
+- Dropped: <list with landmine reference>
+- Replaced: <list with replacement description>
+```
+
+The `Decisions applied` section is the trail of what vertical minimization did. Setup reads it to understand what the component looked like in prod and what's been changed for the test environment.
+
+When vertical classification expands an operator-managed CR into primitives (see `references/operator-recipes.md`), the *Component inventory* will gain multiple entries for what was previously one CR — typically a StatefulSet plus a Service plus possibly a ConfigMap and a Secret. Document each as its own entry; cross-reference them in the `Dependencies in/out` fields so the relationships are visible.
+
+## Defaults Are Defaults
+
+Every vertical decision is the skill applying a default. The customer can override any of them. When applying a default that has meaningful fidelity impact (most landmines), surface the fidelity cost and the override path; do not silently choose speed if the customer cares about fidelity.
+
+The signal that fidelity may matter:
+
+- The customer mentioned testing with the platform layer in prod (e.g., "we test with Istio enabled")
+- The component being dropped has explicit configuration (e.g., AuthorizationPolicies, not just default injection)
+- The customer's k8s comfort level signals SRE expertise — they likely understand the tradeoffs
+
+When fidelity matters, ask the calibration question from the relevant landmine entry. When it doesn't, apply the default and move on.
+
+## Status After Vertical Pass
+
+When vertical classification is complete:
+
+- Every kept component has a Component inventory entry
+- Every entry has status `Confirmed`, `Defaulted`, or `Open`
+- Decisions applied are listed per component, not aggregated globally
+- Update `current_phase` to `7` (stub strategy)
+- Generate any new ops-questions raised during vertical (calibration questions where confidence was low; questions about specific config the customer needs ops input on)
+
+## Output
+
+Working file *Component inventory* section, populated. `current_phase` set to `7`. Updated `ops-questions.md` if any new questions surfaced.


### PR DESCRIPTION
A new skill for customers running on Kubernetes who are getting started with Antithesis. The skill works interactively with the customer (and the Antithesis engagement team) to figure out the test environment for their k8s-based system — what to keep, what to drop, what to stub — when neither side typically has full context on the cluster setup.

The skill produces a structured analysis report under `antithesis/scratchbook/k8s-minimization.md` plus working artifacts under `antithesis/scratchbook/k8s-minimization-work/`. K8s customers run it before `antithesis-setup`.

This skill is more experimental than peer skills in this repo. Unlike research/setup/workload, we can't dogfood it without a real customer engagement, and the first such engagement will surface gaps we couldn't predict synthetically. The README has a NOTE block flagging this and asking for aggressive feedback.

Setup-side k8s support is a separate effort. Until it lands, the skill's final report serves as a structured handoff packet for the Antithesis engagement team rather than a direct setup input.