### PR TITLE
Recommend a simple property first, then switch to priority

### DIFF
--- a/antithesis-workload/SKILL.md
+++ b/antithesis-workload/SKILL.md
@@ -57,7 +57,16 @@ Read whatever provenance frontmatter is present in the catalog and include it wh
 
 Workload runs every property cycle, so don't ask the user to re-confirm provenance every run — display it as context and continue. The user will speak up if it no longer matches the system they're working on. The user-facing commit display uses the short hash (first 12 characters) for readability; the frontmatter still stores the full SHA.
 
-Show the user the status of each property, then recommend one to implement next. Prefer partially-implemented properties that need completion, then unimplemented properties that cluster with recently implemented ones (see `antithesis/scratchbook/property-relationships.md`), then other high-priority unimplemented properties. Wait for the user to confirm or choose differently before proceeding.
+**Recommend one property at a time — don't dump the full catalog.** A catalog can easily have dozens or hundreds of properties; an exhaustive status list is overwhelming and rarely what the user needs. This is the default: pick one, explain why, and wait for confirmation.
+
+The exception is when the user explicitly asks to discuss what to work on rather than receive a single recommendation. In that case, give a high-level summary (counts by status, notable clusters, anything unusual) and have the conversation. Surface specific properties only as the conversation calls for them.
+
+Strategy for picking the recommendation:
+
+- **Getting started** — when few or no properties are implemented yet — recommend a **simple** property: one whose test doesn't have a lot of moving parts. The highest-priority properties tend to require the most setup and coordination, which is the wrong place to start. Simple properties build momentum, exercise the SDK and test harness end-to-end, and let you and the user develop a feel for the workflow. Tell the user this is the strategy you're using and why.
+- **Once you're cooking** — multiple properties implemented and the harness validated end-to-end — switch to priority-based ordering: partially-implemented properties that need completion, then unimplemented properties that cluster with recently implemented ones (see `antithesis/scratchbook/property-relationships.md`), then other high-priority unimplemented properties. Tell the user when you're making this switch.
+
+Explain **why** you picked the property you picked, and wait for the user to confirm or choose differently before proceeding.
 
 For the chosen property, read both the catalog entry and its evidence file.
 
@@ -101,7 +110,7 @@ Use the `antithesis-documentation` skill to access these pages. Prefer `snouty d
 
 ### Implement next property
 
-1. Detect implementation status and present to user (see Scoping above)
+1. Detect implementation status, then recommend one property and explain why (see "Detect implementation status" and "Present and recommend" above)
 2. Get user confirmation on which property to implement
 3. Read `references/component-implementation.md`
 4. Read `references/assertions.md`


### PR DESCRIPTION
The antithesis-workload skill's recommendation strategy had two issues. First, it told the agent to "show the user the status of each property" — fine for tiny catalogs, overwhelming for the dozens-to-hundreds case. Second, it recommended by priority, but the highest-priority properties tend to be the most complex to test, which is the wrong place to start when nothing has been wired up yet.

The new wording recommends one property at a time as the default. When getting started, pick a **simple** property — one whose test doesn't have a lot of moving parts — so the SDK and harness get exercised end-to-end before the hard properties land. Once the workload is cooking, switch to priority-based ordering. Tell the user which strategy you're using and why, and wait for confirmation before implementing.

The workflow checklist (step 1 under "Implement next property") is updated so an agent skimming the terse steps doesn't anchor on the old "present to user" behavior.