### PR TITLE
Recommend a simple property first

### DIFF
--- a/antithesis-workload/SKILL.md
+++ b/antithesis-workload/SKILL.md
@@ -61,7 +61,10 @@ Workload runs every property cycle, so don't ask the user to re-confirm provenan
 
 The exception is when the user explicitly asks to discuss what to work on rather than receive a single recommendation. In that case, give a high-level summary (counts by status, notable clusters, anything unusual) and have the conversation. Surface specific properties only as the conversation calls for them.
 
-Prefer partially-implemented properties that need completion, then unimplemented properties that cluster with recently implemented ones (see `antithesis/scratchbook/property-relationships.md`), then other high-priority unimplemented properties.
+Strategy for picking the recommendation:
+
+- **Getting started** — when few or no properties are implemented yet — recommend a **simple** property: one whose test doesn't have a lot of moving parts. The highest-priority properties tend to require the most setup and coordination, which is the wrong place to start. Simple properties build momentum, exercise the SDK and test harness end-to-end, and let you and the user develop a feel for the workflow. Tell the user this is the strategy you're using and why.
+- **Once you're cooking** — multiple properties implemented and the harness validated end-to-end — switch to priority-based ordering: partially-implemented properties that need completion, then unimplemented properties that cluster with recently implemented ones (see `antithesis/scratchbook/property-relationships.md`), then other high-priority unimplemented properties. Tell the user when you're making this switch.
 
 Explain **why** you picked the property you picked, and wait for the user to confirm or choose differently before proceeding.
 


### PR DESCRIPTION
The previous selection strategy was: prefer partially-implemented properties, then clusters, then high-priority. The trouble is that the highest-priority properties tend to require the most setup and coordination to test, which is the wrong thing to start on when nothing has been wired up yet — the agent and user spend their first property fighting infrastructure instead of learning the workflow.

New strategy: when getting started (few or no properties implemented), recommend a **simple** property — one whose test doesn't have a lot of moving parts. Build momentum, get the SDK and harness exercised end-to-end, develop a feel for the loop. Once that's working ("once you're cooking"), switch to the priority-based ordering above. Tell the user which strategy you're using and why, and announce the switch when you make it.

"Simple" and "cooking" are intentionally judgment-based — the user-confirmation step from #144 is the guardrail. If the agent's judgment of either is wrong, the user redirects.