### PR TITLE
Use `snouty launch` instead of `snouty run`

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Enable AI agents to set up Antithesis, bootstrap your first Antithesis test, lau
 
 `antithesis-query-logs` enables agents to search across all timelines in an Antithesis test run to find events, correlate property failures, and answer temporal questions about ordering and causation — e.g., cascade elimination, fault correlation, and root cause hypothesis testing.
 
-`antithesis-launch` enables agents to build the harness, run `snouty validate`, and submit `snouty run` with sensible metadata once the harness is ready.
+`antithesis-launch` enables agents to build the harness, run `snouty validate`, and submit `snouty launch` with sensible metadata once the harness is ready.
 
 `antithesis-skills-feedback` helps you file bug reports against these skills by opening a pre-filled GitHub issue.
 
@@ -46,7 +46,7 @@ We recommend that you run `antithesis-research`, `antithesis-setup`, and `antith
 
 If your system runs on Kubernetes, run `antithesis-k8s-onboarding-assistance` before `antithesis-setup`. It works with you to figure out which parts of your production k8s setup belong in the test environment, what should be stubbed, and what to drop.
 
-Once the harness is in place, use `antithesis-launch` to run `docker compose build`, `snouty validate`, and `snouty run` in the right order. We recommend running this after the setup and workload skills to ensure everything is working well.
+Once the harness is in place, use `antithesis-launch` to run `docker compose build`, `snouty validate`, and `snouty launch` in the right order. We recommend running this after the setup and workload skills to ensure everything is working well.
 
 Don't hesitate to run short 15-30 minute Antithesis test runs as smoke tests to ensure that the harness is working as expected.
 
@@ -118,7 +118,7 @@ This skill produces the following artifacts, relative to the project directory:
 /antithesis-launch Launch an Antithesis run from this repo for 30 minutes.
 ```
 
-This skill discovers the Antithesis config, builds the harness, validates it with `snouty validate`, and only submits `snouty run` if validation succeeds.
+This skill discovers the Antithesis config, builds the harness, validates it with `snouty validate`, and only submits `snouty launch` if validation succeeds.
 
 ## Compatibility
 

--- a/antithesis-launch/SKILL.md
+++ b/antithesis-launch/SKILL.md
@@ -3,7 +3,7 @@ name: antithesis-launch
 description: >
   Launch an Antithesis run with snouty by discovering the harness layout,
   building the right Docker Compose config, running `snouty validate`,
-  bailing on validation failure, and then submitting `snouty run` with sane
+  bailing on validation failure, and then submitting `snouty launch` with sane
   metadata. Use when the user wants to send, submit, or launch an Antithesis
   run. This skill takes duration in minutes as input.
 compatibility: Requires docker (or podman) with compose and snouty (https://github.com/antithesishq/snouty).
@@ -24,7 +24,7 @@ Launch an Antithesis run in this order only:
 1. `docker compose build`
 2. `snouty validate`
 3. if validation fails, stop and report the error
-4. `snouty run`
+4. `snouty launch`
 
 ## Required Input
 
@@ -36,14 +36,14 @@ Launch an Antithesis run in this order only:
 - Otherwise, inspect the repo to understand how the harness is wired. Check nearby `AGENTS.md`, `README*`, `Makefile*`, and Antithesis-specific scripts before choosing commands.
 - Find the config directory by locating the `docker-compose.yaml` intended for Antithesis. Prefer directories like `antithesis/config`, but support non-standard layouts.
 - Treat these as strong Antithesis signals: nearby `scratchbook/` or `test/` directories, compose content mentioning `/opt/antithesis`, `ANTITHESIS_` env vars, `setup_complete`, or existing `snouty` examples.
-- If multiple compose files look plausible, prefer the one referenced by repo docs or existing `snouty run` examples. If the choice is still ambiguous, ask the user instead of guessing.
-- Use the directory containing `docker-compose.yaml` as the `snouty validate <CONFIG>` and `snouty run --config <CONFIG>` argument.
+- If multiple compose files look plausible, prefer the one referenced by repo docs or existing `snouty launch` examples. If the choice is still ambiguous, ask the user instead of guessing.
+- Use the directory containing `docker-compose.yaml` as the `snouty validate <CONFIG>` and `snouty launch --config <CONFIG>` argument.
 - Build against that exact file with `docker compose -f <CONFIG>/docker-compose.yaml build`. If `docker compose` is unavailable, fall back to `docker-compose -f ... build`.
 
 ## Run Arguments
 
 - Determine the webhook in this order: explicit user input, existing repo docs/scripts/examples, otherwise default to `basic_test`.
-- `snouty run --config` requires `ANTITHESIS_REPOSITORY`. Reuse the current environment if it is already set. If not, stop and ask the user for it.
+- `snouty launch --config` requires `ANTITHESIS_REPOSITORY`. Reuse the current environment if it is already set. If not, stop and ask the user for it.
 - Always set all of these explicitly:
   - `--duration`: the user-provided duration
   - `--source`: repo name
@@ -53,12 +53,13 @@ Launch an Antithesis run in this order only:
 ## Execution
 
 - These commands can take a long time. Prefer background execution or generous timeouts instead of assuming quick completion.
-- Do not run `snouty run` unless the build succeeded and `snouty validate` exited successfully.
+- Do not run `snouty launch` unless the build succeeded and `snouty validate` exited successfully.
 
 ```sh
 docker compose -f "$CONFIG_DIR/docker-compose.yaml" build
 snouty validate "$CONFIG_DIR"
-snouty run \
+snouty launch \
+  --json \
   --webhook "$WEBHOOK" \
   --config "$CONFIG_DIR" \
   --duration "$DURATION" \
@@ -69,13 +70,14 @@ snouty run \
 
 ## Output
 
-- Report the config directory, compose build command, validate command, and final `snouty run` command shape before submission.
+- Report the config directory, compose build command, validate command, and final `snouty launch` command shape before submission.
 - If validation fails, stop immediately and show the failing command plus the key error.
+- The `--json` flag makes `snouty launch` emit machine-readable output containing a `run_id`. Parse and report the run_id — it's needed to triage the run when it is done.
 
 ## Self-Review
 
 - The chosen config directory is the one that actually contains the Antithesis `docker-compose.yaml`.
 - The build, validate, and run steps all point at the same config.
-- `snouty validate` succeeded before `snouty run` was invoked.
+- `snouty validate` succeeded before `snouty launch` was invoked.
 - The run set `source`, `test-name`, `description`, and `duration` explicitly.
 - Missing blockers such as `duration`, `ANTITHESIS_REPOSITORY`, or an ambiguous config location caused a stop instead of a bad submission.

--- a/antithesis-setup/SKILL.md
+++ b/antithesis-setup/SKILL.md
@@ -23,7 +23,7 @@ Success means:
 - the SUT dependency graph includes the relevant Antithesis SDK where assertions or lifecycle hooks will run
 - at least one minimal bootstrap property exists in a simple SUT path and is expected to show up in the first Antithesis run
 - The harness is ready for the `antithesis-workload` skill to add or iterate on test templates, assertions, and workload code
-- If the user asks to submit or launch a run, use the `antithesis-launch` skill — do not run `snouty run` directly
+- If the user asks to submit or launch a run, use the `antithesis-launch` skill — do not run `snouty launch` directly
 
 ## Prerequisites
 
@@ -88,7 +88,7 @@ This skill is broken out into multiple steps, each in a different reference file
   complete until the relevant images expose `/opt/antithesis/catalog/` or
   `/symbols/` correctly for their language.
 - Treat local testing as required before the first submission.
-- Use `snouty run` directly to submit runs. Run `compose build` before `snouty run` to ensure images are up to date.
+- Use `snouty launch` directly to submit runs. Run `compose build` before `snouty launch` to ensure images are up to date.
 - Do not add a separate Dockerfile under `antithesis/config/` unless the
   deployment explicitly requires it.
 - Disable color/ANSI output in every container. Antithesis stores raw bytes and
@@ -115,5 +115,5 @@ Review criteria:
 - All built images target `amd64` (verified via `podman image inspect` or `docker image inspect`)
 - Every service has `NO_COLOR=1` set in its environment (via docker-compose.yaml and/or Dockerfile) to prevent ANSI escape codes in container output
 - The harness is ready for the `antithesis-workload` skill — test template directories exist or are wired for later use
-- If the user asks to launch a run, the `antithesis-launch` skill is used instead of running `snouty run` directly
+- If the user asks to launch a run, the `antithesis-launch` skill is used instead of running `snouty launch` directly
 - Whatever research provenance was present in `sut-analysis.md` and `deployment-topology.md` was described to the user and confirmed before scaffolding began (provenance frontmatter format is defined in the `antithesis-research` skill, `references/scratchbook-setup.md`)

--- a/antithesis-setup/assets/antithesis/AGENTS.md
+++ b/antithesis-setup/assets/antithesis/AGENTS.md
@@ -1,9 +1,9 @@
 This directory contains files relevant to running tests in Antithesis.
 
-Use the `antithesis-setup` skill to scaffold and manage this directory. Use the `antithesis-research` skill to analyze the system and build a property catalog. Use the `antithesis-workload` skill to implement assertions and test commands. Use the `antithesis-launch` skill to build, validate, and submit Antithesis runs — do not run `snouty run` directly.
+Use the `antithesis-setup` skill to scaffold and manage this directory. Use the `antithesis-research` skill to analyze the system and build a property catalog. Use the `antithesis-workload` skill to implement assertions and test commands. Use the `antithesis-launch` skill to build, validate, and submit Antithesis runs — do not run `snouty launch` directly.
 
-**snouty run**
-Use `snouty run --webhook basic_test --config antithesis/config` to start an Antithesis run. Always run `compose build` first to ensure images are up to date.
+**snouty launch**
+Use `snouty launch --json --webhook basic_test --config antithesis/config` to start an Antithesis run. Always run `compose build` first to ensure images are up to date.
 
 **snouty validate**
 Use this command to quickly validate changes to the Antithesis scaffolding. See `snouty validate --help` for details.

--- a/antithesis-setup/assets/antithesis/config/docker-compose.yaml
+++ b/antithesis-setup/assets/antithesis/config/docker-compose.yaml
@@ -5,7 +5,7 @@
 # Prefix `container_name:` and `image:` with the project name.
 # Set `hostname:` to match `container_name:` on every service — Antithesis uses
 # container names for fault injection and log attribution.
-# Local images use `build:` so `compose build` can build them before `snouty run`.
+# Local images use `build:` so `compose build` can build them before `snouty launch`.
 # Public images (e.g. postgres, redis) use `image:` directly.
 # Every service MUST include `platform: linux/amd64` — Antithesis runs on x86-64.
 # Every service MUST set `NO_COLOR=1` — Antithesis stores raw bytes and does

--- a/antithesis-setup/references/config-dir.md
+++ b/antithesis-setup/references/config-dir.md
@@ -16,7 +16,7 @@ The `antithesis/config/` directory should include the files Antithesis needs to 
 
 ## Submission Flow
 
-When using `snouty run --webhook basic_test --config antithesis/config`:
+When using `snouty launch --json --webhook basic_test --config antithesis/config`:
 
-- Build compose services referenced via `build:` by using `compose build` before `snouty run`.
+- Build compose services referenced via `build:` by using `compose build` before `snouty launch`.
 - Let Snouty consume the config directory, interpolate environment variables, and launch the run.

--- a/antithesis-setup/references/docker-compose.md
+++ b/antithesis-setup/references/docker-compose.md
@@ -22,7 +22,7 @@ Every service must set both `container_name:` and `hostname:` to the same value.
 
 Services use one of two patterns:
 
-- **Local images** use `build:` with a context path and `image:` with `name:tag`. Build these before invoking `snouty run`.
+- **Local images** use `build:` with a context path and `image:` with `name:tag`. Build these before invoking `snouty launch`.
 - **Public images** use `image:` directly (e.g. `docker.io/library/postgres:17.2`).
 
 Every service must include `platform: linux/amd64` because Antithesis runs on x86-64. This applies to both local and public images — without it, builds and pulls on ARM hosts (e.g. macOS Apple Silicon) will produce the wrong architecture.

--- a/antithesis-setup/references/instrumentation.md
+++ b/antithesis-setup/references/instrumentation.md
@@ -38,7 +38,7 @@ Write the result down in the Antithesis notebook when the answer is non-obvious.
 
 - Instrument the actual binaries or runtime artifacts that will execute inside Antithesis, not an unrelated local build output.
 - Install the language-appropriate Antithesis SDK into the dependency graph of the code that will emit assertions or lifecycle events.
-- Build and validate instrumentation before the first `snouty run`.
+- Build and validate instrumentation before the first `snouty launch`.
 - If you add assertions later, rerun the relevant instrumentor or rebuild path so assertion cataloging stays current.
 - If a language relies on `/opt/antithesis/catalog/`, avoid symlink chains deeper than one hop inside that tree.
 - If a language relies on `/symbols`, place the files in the image that contains the instrumented software.

--- a/antithesis-setup/references/submit-and-test.md
+++ b/antithesis-setup/references/submit-and-test.md
@@ -22,7 +22,7 @@ Before submitting to Antithesis, test locally:
 ## Environment Setup
 
 - Determine `ANTITHESIS_REPOSITORY` before submission. If it is readable from the current environment, reuse it. Otherwise, ask the user for the registry value.
-- Ensure `ANTITHESIS_REPOSITORY` is exported in the environment before running `snouty run`.
+- Ensure `ANTITHESIS_REPOSITORY` is exported in the environment before running `snouty launch`.
 - Ensure Docker or Podman is authenticated to the registry.
 - For Antithesis-provisioned registries, onboarding covers auth setup.
 - For user-owned registries, configure Docker/Podman login manually.
@@ -38,7 +38,8 @@ export ANTITHESIS_REPOSITORY=registry.example.com/team/project
 podman compose -f antithesis/config/docker-compose.yaml build
 
 # Submit run
-snouty run \
+snouty launch \
+  --json \
   --webhook basic_test \
   --config antithesis/config \
   --test-name "PROJECT_NAME" \

--- a/antithesis-workload/SKILL.md
+++ b/antithesis-workload/SKILL.md
@@ -19,7 +19,7 @@ Implement or improve the Antithesis workload. Success means:
 - The first real test templates are created after setup, or existing ones are expanded
 - Triage findings turn into workload or property updates instead of staying implicit
 
-Use the `antithesis-research` skill first to build the property catalog. Use the `antithesis-setup` skill to scaffold the infrastructure. Use the `antithesis-triage` skill to review runs, then return here to improve the workload. If the user asks to submit or launch a run, use the `antithesis-launch` skill — do not run `snouty run` directly.
+Use the `antithesis-research` skill first to build the property catalog. Use the `antithesis-setup` skill to scaffold the infrastructure. Use the `antithesis-triage` skill to review runs, then return here to improve the workload. If the user asks to submit or launch a run, use the `antithesis-launch` skill — do not run `snouty launch` directly.
 
 ## Prerequisites
 


### PR DESCRIPTION
`snouty` changed its `run` command to `launch` and this update catches the skills up to that. This should make using the skills on a new project start smoother, since the agent will not need to learn how to use `snouty` for launching runs.

