### PR TITLE
Improve randomness usage when creating workloads

### DIFF
--- a/antithesis-workload/references/iteration.md
+++ b/antithesis-workload/references/iteration.md
@@ -19,6 +19,7 @@ After running `antithesis-triage` on a completed test run and reviewing the resu
 
 - Add non-trivial `Sometimes(cond)` assertions when a semantic state should occur at least once.
 - Add new `parallel_driver_` commands to generate more diverse load patterns.
+- Vary probability and action weights across timelines — see `test-commands.md`, "Vary randomness across timelines".
 - Add `anytime_` validation commands to check invariants under active fault injection.
 - Refine `Always` assertions that are too broad or too narrow.
 - Add `Reachable` assertions to confirm the workload or SUT covers expected outcomes and branch results.

--- a/antithesis-workload/references/test-commands.md
+++ b/antithesis-workload/references/test-commands.md
@@ -171,12 +171,27 @@ Randomize aggressively. Every decision in a test command is an opportunity for A
 
 Break commands into the smallest coherent pieces so Antithesis has maximum flexibility in composing test scenarios. Don't tune randomness in ways that rule out valid sequences. A test that always calls `a` twice in a row might find some bugs slightly faster on average, but it can never discover a bug that requires the sequence `a-b-a` without an intervening second `a`. Ruling out valid sequences creates blind spots where bugs hide, and that tradeoff is almost never worth the marginal speedup.
 
+### Vary randomness across timelines
+
+Vary the shape of randomness across timelines. Don't hardcode probabilities and action weights as module-level constants. At the start of each timeline, draw those parameters themselves from a wide range — including the extremes — so some timelines are heavily biased toward one class of action and others are biased the other way.
+
+This is not the same as the rule against ruling out valid sequences above. That warns against permanently encoding "always do `a` twice." This rule says reroll the bias per timeline — across many timelines every valid sequence is still reachable; within any one timeline you go deep.
+
+When every step draws uniformly from a large action space, timelines converge toward the typical state and rarely reach the deep states where the interesting bugs hide. A single timeline that's deliberately skewed goes deep into one corner of the state space; across many timelines, the union of skews covers the surface, and finds bugs uniform mixing never reaches. This is sometimes called swarm testing.
+
+The per-timeline bias should also include action omission — the limiting case of skew, where an entire class of action is excluded from the menu for that timeline. For an action vocabulary `[a, b, c, d]`, drop each independently with some small probability at the start of the timeline, and re-roll if the result is empty.
+
+A simple implementation: for each tunable probability, replace `P = 0.3` with `P = random_choice([0.02, 0.3, 0.95])` from the SDK's random module (see `assertions.md`). Three buckets is illustrative; what matters is covering the extremes plus a middle case. For action weights, occasionally zero out one or more entries. Both stay deterministic under replay; both broaden the state space Antithesis can explore.
+
+This matters most when the action space is large. For small vocabularies or one-shot commands (`first_`, `singleton_driver_`) the gains are limited, and the parameters to vary are the ones tuned at the start of the timeline, not per-step decisions.
+
 ## Guidance
 
 - Antithesis already checks that commands exit 0, so a non-zero exit should mean something is genuinely wrong.
 - Reserve `setup_complete` for a container entrypoint or other long-lived startup process that runs before Antithesis starts executing timeline commands.
 - Driver commands connect to the SUT under active fault injection — handle transient network faults gracefully (see `component-implementation.md` for details).
 - All randomness in test commands must go through the Antithesis SDK's random module for deterministic replay (see `assertions.md` for details).
+- Vary probability and action weights across timelines so different timelines explore different corners of the state space (see "Vary randomness across timelines").
 - Write commands in the project's language, not Bash, so they can reuse existing clients, helpers, and libraries.
 
 ## Output


### PR DESCRIPTION
The workload skill now incorporates the lesson from [swarm testing](https://dl.acm.org/doi/10.1145/2338965.2336763): when every test run draws actions uniformly from the same broad menu, runs converge toward the same average mix and rarely reach the deep states where many bugs live. If each individual run is narrowly biased instead — restricted to a subset of actions, with skewed probabilities — and the biases vary across runs, each run goes deep into one corner of the state space, and the swarm covers far more ground than uniform mixing ever does.

In Antithesis terms: if your workload's probabilities and action weights are baked into the code, every timeline mixes operations in roughly the same proportions. You rarely hit the deep skewed states — long runs of the same action, whole categories never appearing — where a lot of bugs actually live. The new guidance is to draw those probabilities and weights themselves at the start of each timeline, biased toward the extremes including zero (which omits a class of action entirely from that timeline).

The advice lives under "Vary randomness across timelines" in the workload skill's test-commands reference, with a sibling bullet in the Guidance checklist so it surfaces at self-review.