### PR TITLE
workload exit/state guidance; snouty doctor as triage preflight

### DIFF
--- a/.claude/skills/test-triage/SKILL.md
+++ b/.claude/skills/test-triage/SKILL.md
@@ -26,22 +26,23 @@ Before starting, verify the same prerequisites the triage skill requires:
 which snouty && which jq && snouty --version
 ```
 
-`snouty` must be at least version 0.5.0. Also confirm `ANTITHESIS_TENANT` is
-set:
+`snouty` must be at least version 0.5.0. Then confirm credentials with the canonical check (same as the triage skill's preflight):
 
 ```bash
-echo "$ANTITHESIS_TENANT"
+snouty doctor
 ```
 
-If any prerequisite is missing or out of date, stop and report which ones
-are unavailable.
+If any prerequisite is missing, out of date, or `snouty doctor` fails, stop and
+report which ones are unavailable.
 
 ## Phase 1: Discover Runs
 
 Spawn a **general-purpose sub-agent** with the Agent tool. Provide these
 instructions, replacing `{{TENANT}}` with the actual value of the
 `$ANTITHESIS_TENANT` environment variable and `{{TRIAGE_SKILL}}` with the
-absolute path to `antithesis-triage/SKILL.md` in this repository:
+absolute path to `antithesis-triage/SKILL.md` in this repository. If
+`$ANTITHESIS_TENANT` is empty in the current shell, ask the user for the tenant
+name instead of aborting.
 
 ```
 Read the skill file at {{TRIAGE_SKILL}} and follow its instructions to list

--- a/antithesis-triage/SKILL.md
+++ b/antithesis-triage/SKILL.md
@@ -25,21 +25,15 @@ Use this skill to analyze Antithesis test runs.
 
 ### Preflight: confirm triage can work
 
-This version of the triage skill talks to Antithesis through the snouty API (`snouty runs ...`). Several things can prevent that from working. Walk down the checklist below in order — it is ordered from the most-likely cause (auth not exported) to the least-likely (tenant missing API access). Stop at the first failing check and surface **only that cause** to the user; do not list the others. Do not attempt real triage work until every check passes.
+This version of the triage skill talks to Antithesis through the snouty API (`snouty runs ...`). Before doing any work, confirm the setup is ready with the following command:
+
+```bash
+snouty doctor
+```
+
+If this command reports any failure, relay that failure to the user and stop. Do not attempt to interact with the Antithesis API until it passes.
 
 You can skip preflight if you already know (from context or memory) that the user's setup is working.
-
-1. **Is `$ANTITHESIS_API_KEY` set?** This is the most common cause of failure. If unset, tell the user to export it (e.g., `export ANTITHESIS_API_KEY=<their key>`) and stop. Do not speculate about other causes.
-
-2. **Does `snouty doctor` pass?** Run `snouty doctor`. If it reports any failure, relay that failure to the user and stop. Today this mostly re-confirms environment variables, but it is the canonical place where key validity, network reachability, and API-access checks will be surfaced as they are added — so always run it here.
-
-3. **Can the API actually be reached?** Probe with `snouty runs list -n 1`. If this errors, the most likely remaining cause is that the tenant is not yet enrolled in the snouty API rollout. Tell the user to either:
-   - **Contact Antithesis support** to request API access for their tenant, or
-   - **Downgrade this skill** to the previous browser-based version on the
-     `agent-browser-triage` branch:
-     `https://github.com/antithesishq/antithesis-skills/tree/agent-browser-triage`
-
-   This fallback is temporary and will be removed once the rollout completes.
 
 ## Gathering user input
 

--- a/antithesis-workload/references/test-commands.md
+++ b/antithesis-workload/references/test-commands.md
@@ -22,10 +22,28 @@ A test command is an executable file whose filename starts with a recognized pre
 
 - Be marked executable by the container's default user
 - Be a compiled binary or have a shebang line (e.g., `#!/usr/bin/env python3`)
-- Eventually exit
+- A test command _must_ eventually exit (see "Test commands must exit" below)
 - Never emit `setup_complete` — test commands only run after Antithesis receives it, so emitting it from a test command deadlocks startup
 
 Symlinks to existing scripts are supported.
+
+## Test commands must exit
+
+Antithesis runs your test commands on your behalf — you don't invoke them yourself. Each invocation is one unit of work that Antithesis schedules, observes, and replays.
+
+Because of this, **a test command that runs forever is an antipattern.** Antithesis enforces a built-in property — "every test command exits 0 at least once" — and a command that never returns can never satisfy it, so the property fails.
+
+This does **not** mean commands must run quickly. A command may legitimately take a while — driving a long sequence of operations, waiting on the system to reach some state, polling through a retry loop. That's fine. The requirement is only that it _eventually_ finishes and returns an exit code. Structure each command as one bounded chunk of work (drive N operations, run for a bounded time/iteration budget, then exit) and let Antithesis re-run it to get more — rather than looping indefinitely inside a single invocation. Antithesis already checks the exit code, so a non-zero exit should mean something is genuinely wrong.
+
+## Maintaining state between commands
+
+Because each command invocation is a separate, bounded process (see "Test commands must exit"), any state that needs to outlive a single invocation — counters of attempted operations, sequence numbers, expected-value bookkeeping, a record of what's been done so far — has to live somewhere outside the process.
+
+The easiest mechanism is a **shared volume mounted into the relevant containers** in the Docker Compose file. Every container in an Antithesis run executes on the same physical host, so a shared volume is just the same local filesystem visible from each container. Test commands across containers can read and write it as ordinary local files.
+
+For most cases, **plain files are enough**. When you need **safe concurrent access** — multiple `parallel_driver_` invocations touching the same state at once, or anything that needs transactional/atomic updates — use **SQLite** on that shared filesystem. SQLite handles the locking and gives you transactions, so reserve it for state that is complex, concurrently accessed, or must be updated atomically; reach for simple files otherwise.
+
+You do **not** need to reason about replay, branching, or timelines when persisting state. Antithesis makes all of that deterministic and transparent: the SUT and your commands only ever experience a single linear history, and you should write state-handling code under exactly that premise.
 
 ## Test Command Prefixes and Their Behavior
 
@@ -88,25 +106,25 @@ Symlinks to existing scripts are supported.
 
 These two command types are similar but serve different purposes:
 
-| Aspect | `eventually_` | `finally_` |
-|--------|---------------|------------|
-| Question answered | "Does the system recover?" | "Is the final state correct?" |
-| When it runs | After driver(s) start | After all drivers complete naturally |
-| How drivers end | Killed by Antithesis | Completed on their own |
-| Faults | Stopped | Stopped |
-| Destructive actions | Safe — branch won't resume | Safe — branch won't resume |
+| Aspect              | `eventually_`              | `finally_`                           |
+| ------------------- | -------------------------- | ------------------------------------ |
+| Question answered   | "Does the system recover?" | "Is the final state correct?"        |
+| When it runs        | After driver(s) start      | After all drivers complete naturally |
+| How drivers end     | Killed by Antithesis       | Completed on their own               |
+| Faults              | Stopped                    | Stopped                              |
+| Destructive actions | Safe — branch won't resume | Safe — branch won't resume           |
 
 ## Concurrency Summary
 
-| Command | Faults active? | Can run alongside |
-|---------|---------------|-------------------|
-| `first_` | No | Nothing |
-| `parallel_driver_` | Yes | `parallel_driver_`, `anytime_` |
-| `serial_driver_` | Yes | `anytime_` |
-| `singleton_driver_` | Yes | `anytime_` |
-| `anytime_` | Yes (during drivers) | Any except `first_`; during `eventually_`/`finally_`, running instances complete but new ones are not started |
-| `eventually_` | No | Running `anytime_` commands complete |
-| `finally_` | No | Running `anytime_` commands complete |
+| Command             | Faults active?       | Can run alongside                                                                                             |
+| ------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `first_`            | No                   | Nothing                                                                                                       |
+| `parallel_driver_`  | Yes                  | `parallel_driver_`, `anytime_`                                                                                |
+| `serial_driver_`    | Yes                  | `anytime_`                                                                                                    |
+| `singleton_driver_` | Yes                  | `anytime_`                                                                                                    |
+| `anytime_`          | Yes (during drivers) | Any except `first_`; during `eventually_`/`finally_`, running instances complete but new ones are not started |
+| `eventually_`       | No                   | Running `anytime_` commands complete                                                                          |
+| `finally_`          | No                   | Running `anytime_` commands complete                                                                          |
 
 ## Requesting Quiet Periods from Driver Commands
 
@@ -141,11 +159,11 @@ This is especially useful during rolling operations (upgrades, config changes, m
 
 ### When to Use Which
 
-| Mechanism | Faults paused? | Test continues after? | Use case |
-|-----------|---------------|----------------------|----------|
-| `eventually_` command | Yes | No (terminal branch) | Final liveness validation |
-| `finally_` command | Yes | No (terminal branch) | Post-driver invariant checks |
-| `ANTITHESIS_STOP_FAULTS` | Yes | Yes (faults resume) | Mid-run recovery checks, rolling operations |
+| Mechanism                | Faults paused? | Test continues after? | Use case                                    |
+| ------------------------ | -------------- | --------------------- | ------------------------------------------- |
+| `eventually_` command    | Yes            | No (terminal branch)  | Final liveness validation                   |
+| `finally_` command       | Yes            | No (terminal branch)  | Post-driver invariant checks                |
+| `ANTITHESIS_STOP_FAULTS` | Yes            | Yes (faults resume)   | Mid-run recovery checks, rolling operations |
 
 ## Design Principles
 


### PR DESCRIPTION
Two unrelated skill-content changes.

**Workload skill** (`references/test-commands.md`). Adds guidance on why test commands need to exit: Antithesis runs them on our behalf, repeatedly and usually at high parallelism (or, for a serial driver, over and over), so a command that runs forever is an antipattern — it can never satisfy the built-in "every test command exits 0 at least once" property and it starves the scheduler. This doesn't mean commands must be fast; they may legitimately take a while, but they must eventually finish. Also documents how to maintain state between command invocations: the easiest mechanism is a shared volume in docker-compose (every container runs on the same physical host, so it's the same local filesystem), with plain files for most cases and SQLite when you need safe concurrent or transactional access. Replay, branching, and timelines are transparent — write state code as if there's a single linear history.

**Triage skill.** Makes `snouty doctor` the single canonical preflight check, dropping the `$ANTITHESIS_API_KEY` shell-export gate and the separate `snouty runs list` probe so the skill stops duplicating checks that belong in snouty and won't drift from it. The same simplification is applied to the internal `test-triage` harness. This is the action item carried over from #156; the 404/old-run handling from that PR is intentionally left out, since it's being handled in snouty (run-ID version detection) rather than encoded in the skill.