### PR TITLE
docs: explain why assertion property names must be inline, constant, and unique

### DIFF
--- a/antithesis-setup/references/instrumentation.md
+++ b/antithesis-setup/references/instrumentation.md
@@ -68,6 +68,8 @@ Good property shape:
 
 Keep this first property extremely simple. Its purpose is integration verification, not business validation. Use a stable, human-readable message so its history remains comparable across runs.
 
+The property name must be an inline constant string literal, unique across the project — never constructed at runtime (no `"prefix" + id`) and never passed through a variable. Assertion cataloging statically analyzes the software to learn which assertions to expect before any run (at compile time for statically compiled languages like Rust, C++, and Go; via a runtime scan for dynamic languages like Java and Python), so a dynamic or duplicated name silently breaks cataloging.
+
 After setup proves the SDK path works, later workload work should extend SUT-side instrumentation at rare or dangerous internal outcomes when that will guide search better than workload-only assertions.
 
 ## Language-Specific References

--- a/antithesis-workload/SKILL.md
+++ b/antithesis-workload/SKILL.md
@@ -151,7 +151,7 @@ Review criteria:
 - For every property in scope, the implementation covers the code paths, failure scenarios, and instrumentation points described in its evidence file — not just "an assertion exists" but "the assertions cover what the evidence says needs to be covered"
 - Each assertion uses the correct SDK assertion type for its property's semantics (`Always`/`AlwaysOrUnreachable` for safety, `Sometimes(cond)` for liveness or meaningful semantic state, `Reachable`/`Unreachable` for path and outcome checks)
 - `Sometimes(true, ...)` assertions should be rewritten as `Reachable(...)`.
-- Assertion messages are unique across the touched code; no broad property is implemented by reusing one message at multiple unrelated callsites
+- Assertion property names are inline constant string literals, unique across the whole project — never built at runtime or passed through variables (static analysis must pre-catalog them; see `references/assertions.md` "Naming"); no broad property is implemented by reusing one message at multiple unrelated callsites
 - Workload-only instrumentation was not used where surgical SUT-side assertions would provide materially better search guidance for rare, dangerous, or timing-sensitive internal states
 - Workload code makes progress toward stated goals under transient errors rather than bailing on first failure
 - The workload records both attempted and acknowledged operations so later assertions can check bounds (e.g., "counter changed by some value in `[acknowledged, attempted]`")

--- a/antithesis-workload/references/assertions.md
+++ b/antithesis-workload/references/assertions.md
@@ -80,6 +80,7 @@ Don't write `Always(observed_delta == 100, ...)` for the same property — that 
 - Do not use `Sometimes(true, ...)` in normal workload or SUT code. If the condition is constant true, use `Reachable(...)` instead.
 - Do not use `Sometimes(cond, ...)` when the only thing you care about is that execution hit a path. Use `Reachable(...)`.
 - Do not reuse one assertion message across multiple unrelated callsites. Every assertion message should be unique in the codebase.
+- Do not construct assertion property names at runtime or pass them through variables. The name must be an inline constant string literal at the callsite — see "Naming" for why static analysis requires this.
 - Do not stack broad early `Reachable(...)` markers on a straight-line flow when a later, more specific outcome marker already proves the path was exercised.
 - Do not assert exact equality on values affected by transient errors. Use bounded assertions (see "Assert Bounds, Not Exact Values").
 
@@ -122,3 +123,13 @@ For guidance on which values to draw from — boundary values, configured-limit 
 ## Naming
 
 Give assertions clear, descriptive, unique names. These names appear in triage reports, so they should be immediately understandable and should localize one specific callsite or condition.
+
+The property name argument of every SDK assertion call (e.g. the "foobar" in `antithesis.assertAlways("foobar", ...)`) must be:
+
+- **Inline** — a string literal written directly at the callsite, not a variable, constant reference, or function result.
+- **Constant** — never constructed at runtime. No concatenation (`"foo" + id`), format strings, or interpolation.
+- **Unique** — no two assertion callsites anywhere in the project may share a property name.
+
+These are hard requirements, not style preferences. Antithesis statically analyzes all software during instrumentation to pre-catalog every assertion before any test runs. Pre-cataloging is what makes reachability and unreachability meaningful: to report that a `Reachable` was never hit or that an `Unreachable` exists, Antithesis must know the full set of assertions not just the ones it has seen fire so far. A name built at runtime is invisible to static analysis, a name passed through a variable may not resolve, and a duplicated name collapses two distinct callsites into one catalog entry, corrupting both.
+
+When the static analysis happens depends on the language: statically compiled languages (Rust, C++, Go) are cataloged during compile-time instrumentation; dynamic languages (Java, Python, etc.) are scanned at runtime.


### PR DESCRIPTION
The skills that teach agents to write Antithesis SDK assertions (antithesis-workload, and the bootstrap assertion in antithesis-setup) told agents to use unique assertion messages, but never stated the full requirement or the reason behind it. This adds a surgical note explaining that the property name argument of every assertion must be **inline** (a string literal at the callsite, not a variable), **constant** (never built at runtime via concatenation or formatting), and **unique** across the whole project.

The why: Antithesis statically analyzes all software during instrumentation to pre-catalog assertions. Because assertions imply (un)reachability, the platform must know which assertions to *expect*, not just which ones have fired so far. For statically compiled languages (Rust, C++, Go) this analysis happens during compile-time instrumentation; for dynamic languages (Java, Python, etc.) it happens via a runtime scan. A runtime-built name is invisible to that analysis, and a duplicated name collapses two callsites into one catalog entry.

Changes:
- `antithesis-workload/references/assertions.md`: expanded the "Naming" section with the three requirements and the static-analysis rationale, and added an anti-rule against runtime-constructed names.
- `antithesis-workload/SKILL.md`: tightened the review-criteria bullet to check for inline constant unique names, pointing at the Naming section.
- `antithesis-setup/references/instrumentation.md`: added a brief note in the Bootstrap Assertion Requirement so the very first assertion already follows the rule.

Validation: `make validate` passes (11 skills checked).