### PR TITLE
debug: launch MVD sessions directly from run_id

### DIFF
--- a/antithesis-agent-browser/SKILL.md
+++ b/antithesis-agent-browser/SKILL.md
@@ -157,6 +157,5 @@ After every report `waitForReady()` call, check `result.error`. If it is present
 2. **Discover runs from the runs page.** Read `references/run-discovery-ui.md`. Prefer `snouty runs list` whenever possible — only fall back to the UI when the API is unavailable or doesn't expose what you need.
 3. **Read properties from a triage report.** Read `references/properties-from-ui.md`. Prefer `snouty runs --json properties` whenever possible.
 4. **Look up a `run_id` from a triage-report URL** that cannot be matched against `snouty runs list`. The `run_id` is rendered at the bottom of the main report page (`report_id → run_id` is not currently exposed by the API).
-5. **Look up the `session_id` for `snouty debug`.** Load the report that matches the `run_id` (find with `snouty runs --json show $RUN_ID`) and read the `session_id` from the bottom of the report page.
-6. **Download an error log from a failed run's report page.** See `references/error-reports.md`.
-7. **Read a causality report.** Ask the user for the causality report URL. The main signal is the bug-probability trajectory in the logs leading up to the bug moment.
+5. **Download an error log from a failed run's report page.** See `references/error-reports.md`.
+6. **Read a causality report.** Ask the user for the causality report URL. The main signal is the bug-probability trajectory in the logs leading up to the bug moment.

--- a/antithesis-debug/SKILL.md
+++ b/antithesis-debug/SKILL.md
@@ -1,11 +1,9 @@
 ---
 name: antithesis-debug
 description: >
-  Use this skill to interactively debug Antithesis test runs using the
-  multiverse debugger (MVD session). Open a debugging-session URL, inspect container
-  filesystems and runtime state, run shell commands, and extract evidence
-  from inside the Antithesis environment. Supports both the simplified
-  debugger (default) and the advanced notebook mode.
+  Interactively debug an Antithesis test run in the multiverse debugger
+  (MVD): launch a session from a run, open a debugging-session URL, and
+  inspect container filesystem and runtime state from inside the run.
 compatibility: Requires agent-browser v0.23.4+ (https://github.com/vercel-labs/agent-browser).
 metadata:
   version: "2026-06-18 8a80ff6"
@@ -36,6 +34,11 @@ Use this when:
 For auth and report navigation, use the `antithesis-agent-browser` skill. It
 owns the `agent-browser` session and authentication flow. This skill handles
 the debugger itself.
+
+## Prerequisites
+
+- DO NOT PROCEED if `agent-browser` is not installed. See `https://raw.githubusercontent.com/vercel-labs/agent-browser/refs/heads/main/README.md` for installation options.
+- DO NOT PROCEED if `agent-browser` is older than version `v0.23.4`. You can upgrade with `agent-browser upgrade`.
 
 ## Gathering user input
 

--- a/antithesis-debug/references/setup-session.md
+++ b/antithesis-debug/references/setup-session.md
@@ -1,66 +1,59 @@
 # Setup & Session
 
-## Prerequisites
-
-If `agent-browser` is not installed you can install it like so:
-
-```
-npm install -g agent-browser
-agent-browser install
-```
-
-You should also make sure the `agent-browser` skill is available. If it is not available, install it like so:
-
-```
-npx skills add vercel-labs/agent-browser
-```
-
 ## Launching an MVD session
 
-Before opening a debugger URL, you may need to launch the session first.
-`snouty debug` is the launch command. The interface is in flux: feature-detect
-by inspecting `snouty debug --help` before deciding which flow to run.
+Before opening a debugger URL, you may need to launch the session first. If the
+user already gave you a debugging-session URL, skip this section. Launching
+requires `snouty`:
 
-### Step 1: detect the supported parameter
+- DO NOT PROCEED if `snouty` is not installed. See
+  `https://raw.githubusercontent.com/antithesishq/snouty/refs/heads/main/README.md`
+  for installation options.
+- DO NOT PROCEED if `snouty` is not at least version 0.5.0. Use `snouty
+--version` to find the version.
 
-```bash
-snouty debug --help
-```
-
-Look for `run_id` or `session_id` in the parameter list.
-
-### Step 2a — if `run_id` is supported (preferred path)
-
-Launch the session directly given the run + moment:
+`snouty debug` is the launch command. Identify the target run with exactly
+one of `--run-id` (preferred) or `--session-id`, and pin the moment to debug
+with `--input-hash` and `--vtime`:
 
 ```bash
 snouty debug \
-  --antithesis.debugging.run_id "$RUN_ID" \
-  --antithesis.debugging.input_hash "$INPUT_HASH" \
-  --antithesis.debugging.vtime "$VTIME" \
-  --antithesis.debugging.description "$DESCRIPTION" \
-  --antithesis.report.recipients "$EMAIL"
+  --run-id "$RUN_ID" \
+  --input-hash "$INPUT_HASH" \
+  --vtime "$VTIME" \
+  --description "$DESCRIPTION" \
+  --recipients "$EMAIL"
 ```
 
-Always pass a `description`, and make it **unique and findable later**
-(e.g., include the property name, a date stamp, or a ticket id). You'll
-use this string to locate the session in the list of debugging sessions
-when you (or a teammate) want to come back to it.
+`--description` is optional, but always pass one and make it **unique and
+findable later** (e.g., include the property name, a date stamp, or a ticket
+id) — you'll use this string to locate the session in the list of debugging
+sessions when you (or a teammate) come back to it. `--recipients` is an
+optional semicolon-delimited list of emails to notify.
+
+### Getting the input hash and vtime
+
+`--input-hash` and `--vtime` pin the single moment to debug. Extract the input hash and vtime from context and pass them as flags. (`--input-hash` is often negative; keep the leading `-`.)
+
+Infer which moment to use based on the user's prompt. The user may ask you to get a moment from a few different sources:
+
+- A `Moment.from({ ... })` blob from the report's _copy moment_ button, a
+  copied log line, or some free-form message — read the `input_hash` and `vtime`
+  out of it yourself.
+- **The API.** Moments come back from `snouty runs show $RUN_ID` (the failure
+  moment of an incomplete run), `snouty runs properties $RUN_ID --detail`
+  (example / counterexample moments per property), and the `moment` attached
+  to every entry from `snouty runs logs` and `snouty runs events`.
+- **An instruction to go find one.** If the user says something like "debug the
+  failing `Counter` property" or "start a debugging session at an event
+  containing the error message XYZ," use the API sources above to resolve the
+  concrete input hash and vtime first.
+
+If you can't pin down both an input hash and a vtime from a clear source, ask
+the user rather than guessing.
 
 Snouty returns the debugging-session URL on success; proceed to "Opening a
 debugger URL" below.
-
-### Step 2b — if only `session_id` is supported (current state)
-
-`session_id` and `run_id` are not interchangeable. Until `snouty debug` gains
-`run_id` support, ask the user to:
-
-1. Start the MVD session manually from the triage report (or however they
-   normally launch).
-2. Paste the resulting debugging-session URL back to you.
-
-Then proceed with "Opening a debugger URL" using that URL. This is a temporary
-fallback; once snouty supports `run_id`, this step goes away.
 
 ## Session naming
 


### PR DESCRIPTION
The next Antithesis release (rc56.2) lets the MVD debugging launch webhook (`/api/v1/launch/debugging`) accept a `run_id` param in lieu of `session_id`. This simplifies the debug skill's launch flow: `references/setup-session.md` previously feature-detected which parameter `snouty debug` supported and fell back to asking the user to launch the session manually and paste the URL back. That flow is now a single `snouty debug --antithesis.debugging.run_id ...` invocation with no session-id lookup, assuming all tenants support `run_id`.

The corresponding "look up the `session_id` for `snouty debug`" capability is removed from the antithesis-agent-browser skill, since nothing needs it anymore.

**Blocker:** do not merge until rc56.2 has been rolled out to all tenants — manually verify the rollout is complete first. The skill assumes every tenant accepts `run_id`, and the session-id fallback is gone.

Validation: `make validate` passes (11 skills checked).

fixes #159