### PR TITLE
docs: clarify first_ selection and when test commands should exit non-zero

### DIFF
--- a/antithesis-workload/references/test-commands.md
+++ b/antithesis-workload/references/test-commands.md
@@ -35,6 +35,12 @@ Because of this, **a test command that runs forever is an antipattern.** Antithe
 
 This does **not** mean commands must run quickly. A command may legitimately take a while — driving a long sequence of operations, waiting on the system to reach some state, polling through a retry loop. That's fine. The requirement is only that it _eventually_ finishes and returns an exit code. Structure each command as one bounded chunk of work (drive N operations, run for a bounded time/iteration budget, then exit) and let Antithesis re-run it to get more — rather than looping indefinitely inside a single invocation. Antithesis already checks the exit code, so a non-zero exit should mean something is genuinely wrong.
 
+## Exit non-zero only on a real bug
+
+Antithesis attaches a built-in property to each test command that fails whenever that command exits non-zero. So a test command should exit non-zero only when it has genuinely uncovered a bug. Even then, prefer to flag the bug with an Antithesis SDK assertion (`Always`/`Sometimes`/etc.) rather than relying on the exit code — assertions are more controllable and are reported as named property failures with full context.
+
+This is tricky under fault injection, where a SUT call can crash on something transient and expected — a dropped connection, a timeout, a partitioned or restarting node. Bailing on the first such error exits non-zero for something that is not a bug. So test commands should retry as much as needed rather than bailing. That way a non-zero exit means the command hit *actually* unexpected state, and a human should look — to either fix the test command or fix the bug the failure exposed.
+
 ## Maintaining state between commands
 
 Because each command invocation is a separate, bounded process (see "Test commands must exit"), any state that needs to outlive a single invocation — counters of attempted operations, sequence numbers, expected-value bookkeeping, a record of what's been done so far — has to live somewhere outside the process.
@@ -50,10 +56,10 @@ You do **not** need to reason about replay, branching, or timelines when persist
 ### `first_`
 
 - **Purpose:** One-time per-timeline initialization.
-- **Scheduling:** Runs after `setup_complete` but before all other commands. If multiple `first_` commands exist, Antithesis selects exactly one.
+- **Scheduling:** Runs after `setup_complete` but before all other commands. If a template has multiple `first_` commands, exactly one runs on every timeline using that template.
 - **Faults:** Not injected.
 - **Concurrency:** No other commands run alongside.
-- **Notes:** The `setup_complete` deadlock risk (see Test Command Requirements) is especially easy to trigger here, since `first_` commands handle initialization logic.
+- **Notes:** The `setup_complete` deadlock risk (see Test Command Requirements) is especially easy to trigger here, since `first_` commands handle initialization logic. As only one `first_` command runs per timeline, ensure that each `first_` command fully prepares the environment for testing.
 
 ### `parallel_driver_`
 


### PR DESCRIPTION
Two clarifications to the antithesis-workload test-commands reference, each addressing a reported issue.

The first concerns `first_` commands. Antithesis selects exactly one `first_` command per timeline when a template defines several, but the reference only stated that fact in passing — agents could still split initialization across multiple `first_` commands (including across containers that share a template) and end up with half-initialized timelines. The `first_` section now makes the implication explicit: each `first_` command must fully prepare the environment on its own.

The second adds guidance on exit codes, addressing a case where the workload skill wrote a driver that exited non-zero whenever a SUT call failed. Each test command has a built-in property that fails on any non-zero exit, so bailing on a transient fault — a dropped connection, timeout, or partitioned/restarting node — surfaces as a false-positive test failure. The new "Exit non-zero only on a real bug" section directs commands to flag genuine bugs with SDK assertions and to retry transient errors as much as needed rather than bailing, so a non-zero exit only ever means genuinely unexpected state worth investigating.

fixes #65
fixes #52