### PR TITLE
fix: gate agent-browser interactive auth on user confirmation

### DIFF
--- a/antithesis-agent-browser/SKILL.md
+++ b/antithesis-agent-browser/SKILL.md
@@ -76,7 +76,7 @@ agent-browser --session "$SESSION" wait --load networkidle
 agent-browser --session "$SESSION" get url
 ```
 
-If the URL starts with `https://$TENANT.antithesis.com` then you are authenticated. If it redirected to a login page, you need to authenticate — read `references/setup-auth.md`.
+If the URL starts with `https://$TENANT.antithesis.com` then you are authenticated. If it redirected to a login page, you need to authenticate — read `references/setup-auth.md`, which gates the interactive headed login on user confirmation.
 
 ## Runtime injection
 

--- a/antithesis-agent-browser/references/setup-auth.md
+++ b/antithesis-agent-browser/references/setup-auth.md
@@ -1,12 +1,29 @@
 # Authentication
 
 If the shared `--session-name antithesis` state does not leave you
-authenticated, run an interactive login flow. `agent-browser` will save the
-session state automatically because you are using `--session-name`.
+authenticated, run the interactive login flow below. It opens a real, visible
+browser window for sign-in and 2FA; `agent-browser` saves the session
+automatically because you pass `--session-name`.
 
-Authentication requires running `agent-browser` with `--headed` which allows
-the user to sign in and handle 2FA themselves. Use the following commands to
-open a browser window for login, then ask the user to complete auth:
+## Pre-flight: confirm before opening a window
+
+Never open the login window blind — an unannounced window reads as a security
+scare, and a user who walked away (or closes it in annoyance) leaves you
+waiting on a sign-in that never completes.
+
+On Linux, check `DISPLAY` and `WAYLAND_DISPLAY`: if neither is set, this is
+very likely a remote/headless machine where no window can be shown. On macOS
+or elsewhere you cannot tell from the environment.
+
+In every case, before opening anything, tell the user a window is about to
+appear for sign-in and ask them to confirm they are present and ready — and to
+report if no window shows up, so you stop instead of looping. Only open it once
+they confirm. If they cannot see a browser or are not available, STOP: do not
+open a window or retry; suggest running you on a machine with a display.
+
+## Interactive login
+
+Open the headed login window:
 
 ```sh
 agent-browser --session "$SESSION" close
@@ -22,3 +39,6 @@ agent-browser --session "$SESSION" close
 agent-browser --session "$SESSION" --session-name antithesis open "https://$TENANT.antithesis.com"
 agent-browser --session "$SESSION" get url
 ```
+
+If this still redirects to a login page, the interactive auth did not
+complete. Do NOT loop on the auth check — surface the failure to the user.


### PR DESCRIPTION
When the shared `--session-name antithesis` session isn't authenticated, `antithesis-agent-browser` ran the `--headed` login flow unconditionally. On a remote or headless machine the browser opens where no one can see it and the auth check loops forever — what #166 describes as "just flails."

This adds a pre-flight gate to `references/setup-auth.md`. On Linux it does a best-effort display check (`DISPLAY`/`WAYLAND_DISPLAY`) to gauge whether a window can even be shown, and in every case it requires the agent to announce the incoming window and wait for the user to confirm they're present before opening it. The user is primed to report if no window appears, so the agent stops instead of looping. If the user can't see a browser or isn't available, the skill stops cleanly and suggests running on a machine with a display — without dumping `agent-browser` session-setup commands on them.

The detection only shapes the message; the universal rule is to confirm before throwing a browser window in the user's face (which can otherwise read as a security scare, or get closed out of annoyance).

Docs-only change to `SKILL.md` and the auth reference; `make validate` passes.

fixes #166