### PR TITLE
fix: don't repurpose ANTITHESIS_SDK_LOCAL_OUTPUT for setup-complete

### DIFF
--- a/antithesis-setup/assets/antithesis/setup-complete.sh
+++ b/antithesis-setup/assets/antithesis/setup-complete.sh
@@ -9,14 +9,11 @@ set -euo pipefail
 # automatically. This script is setup to emit `setup_complete` to the
 # `sdk.jsonl` file in that directory.
 
-OUTPUT_PATH="/tmp/antithesis_sdk.jsonl"
 if [[ -n "${ANTITHESIS_OUTPUT_DIR:-}" ]]; then
   OUTPUT_PATH="${ANTITHESIS_OUTPUT_DIR}/sdk.jsonl"
+  mkdir -p $(dirname "$OUTPUT_PATH")
   echo "Running in Antithesis, emitting setup_complete to ${OUTPUT_PATH}"
-elif [[ -n "${ANTITHESIS_SDK_LOCAL_OUTPUT:-}" ]]; then
-  OUTPUT_PATH="${ANTITHESIS_SDK_LOCAL_OUTPUT}"
-  echo "Antithesis SDK local output override detected, emitting setup_complete to ${OUTPUT_PATH}"
+  echo '{"antithesis_setup":{"status":"complete","details":{"message":"ready to go"}}}' >> "${OUTPUT_PATH}"
+else
+  echo "\$ANTITHESIS_OUTPUT_DIR is unset, not emitting setup-complete"
 fi
-
-mkdir -p $(dirname "$OUTPUT_PATH")
-echo '{"antithesis_setup":{"status":"complete","details":{"message":"ready to go"}}}' >> "${OUTPUT_PATH}"

--- a/antithesis-setup/references/docker-images.md
+++ b/antithesis-setup/references/docker-images.md
@@ -62,7 +62,7 @@ Set this environment variable in every Dockerfile (or in docker-compose.yaml env
 ENV NO_COLOR=1
 ```
 
-`NO_COLOR` is a widely adopted convention (see https://no-color.org/) honored by most CLI tools, test frameworks, and language runtimes.
+`NO_COLOR` is a widely adopted convention honored by most CLI tools, test frameworks, and language runtimes.
 
 Additionally, if the SUT or its dependencies have their own color flags (e.g. `--no-color`, `FORCE_COLOR=0`, `GCC_COLORS=`, `PYTEST_ADDOPTS=--no-header -p no:color`), disable those too. The goal is zero ANSI escape sequences in any container output.
 

--- a/antithesis-setup/references/language/rust.md
+++ b/antithesis-setup/references/language/rust.md
@@ -23,7 +23,7 @@ Call `antithesis_sdk::antithesis_init()` as soon as possible at program startup.
 
 Outside Antithesis, behavior depends on the build:
 
-- **`full` feature (the default):** the SDK is fully compiled in — assertions evaluate, the catalog registers, and randomness functions return values. Reporting is silent unless you set `ANTITHESIS_SDK_LOCAL_OUTPUT` to a file path, in which case assertion and lifecycle events are written there as JSON.
+- **`full` feature (the default):** the SDK is fully compiled in — assertions evaluate, the catalog registers, and randomness functions return values.
 - **default features disabled:** a true no-op — assertion and lifecycle calls compile away to nothing.
 
 ## Instrumentation


### PR DESCRIPTION
`setup-complete.sh` previously fell back to writing the `setup_complete` event to `ANTITHESIS_SDK_LOCAL_OUTPUT` when `ANTITHESIS_OUTPUT_DIR` was unset. That variable is only meant for redirecting output from the library SDKs; using it as a generic output path for the shell script implied a broader role than it has. The script now emits only when `ANTITHESIS_OUTPUT_DIR` is set (creating the directory as needed) and otherwise prints a clear no-op message and exits cleanly under `set -euo pipefail`.

This also drops the `ANTITHESIS_SDK_LOCAL_OUTPUT` mention from the Rust instrumentation reference, since it isn't a concept the skills need to surface and can be inferred from the docs.

Verified the script in both branches: with `ANTITHESIS_OUTPUT_DIR` set it creates the (possibly nested) output directory, appends valid JSON, and exits 0; with the variable unset or empty it prints the no-op message and exits 0.