### PR TITLE
Add Getting Started documentation for working with LLM agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Enable AI agents to set up Antithesis, bootstrap your first Antithesis test, launch Antithesis runs, and triage the results.
 
 > Table of contents:  
-> **[Recommended workflow](#recommended-workflow)** · **[Starter prompts](#starter-prompts)** · **[Prerequisites](#prerequisites)** · **[Install](#install)**
+> **[Working with LLM agents](#working-with-llm-agents)** · **[Recommended workflow](#recommended-workflow)** · **[Starter prompts](#starter-prompts)** · **[Prerequisites](#prerequisites)** · **[Install](#install)**
 
 ## Skills overview
 
@@ -35,6 +35,12 @@ Enable AI agents to set up Antithesis, bootstrap your first Antithesis test, lau
 
 > [!NOTE]
 > These skills are under active development. LLMs are inherently non-deterministic, so they may not work perfectly with your AI. Please do file issues and submit PRs as you come across ways to improve them.
+
+## Working with LLM agents
+
+These skills run inside an agent like Claude Code or Codex. Using them well means knowing how to work with the agent itself, not just the skills.
+
+If you're new to agentic tools, or you've been using them for a while and want to dig deeper, read [Getting Started with Antithesis Skills](getting-started-documentation/). It's a companion guide covering mental model, day-to-day working patterns, context and memory, building up your harness, and recognizing failure modes.
 
 ## Recommended workflow
 

--- a/getting-started-documentation/README.md
+++ b/getting-started-documentation/README.md
@@ -1,0 +1,50 @@
+# Getting Started with Antithesis Skills
+
+A companion for working productively with LLM agents — Claude Code, Codex, or whatever you're using — while using our Antithesis skills to test your software. Read it through the first time; come back to chapters as you need them after that.
+
+## Table of contents
+
+1. [Getting Oriented](getting-oriented.md)
+2. [The Right Mental Model](mental-model.md)
+3. [Working with Your Agent](working-with-your-agent.md)
+4. [Context and Memory](context-and-memory.md)
+5. [Building Your Harness](building-your-harness.md)
+6. [When Things Go Sideways](when-things-go-sideways.md)
+7. [The Outputs Are Yours](outputs-are-yours.md)
+8. [Where Next?](where-next.md)
+
+Reference: [Glossary](glossary.md)
+
+## Overview
+
+### 1. [Getting Oriented](getting-oriented.md)
+
+Who this guide is for, what knowledge it assumes — testing experience, basic Antithesis familiarity, some LLM exposure, terminal fluency — and how to use the guide. Linear first time, reference after.
+
+### 2. [The Right Mental Model](mental-model.md)
+
+The mindset for working with LLM agents. Agents sound authoritative even when they're wrong; non-determinism is both a feature and a weakness; capability is uneven; collaborator not oracle; you're the pilot.
+
+### 3. [Working with Your Agent](working-with-your-agent.md)
+
+The mechanics of day-to-day work. Talking to the agent like a teammate, asking the agent about itself, iterating in small loops, asking for refactors when patches accumulate, pushback as a primary mode, stepping in directly when needed, second opinions via sub-agents and fresh sessions, and ensemble methods.
+
+### 4. [Context and Memory](context-and-memory.md)
+
+How agents work on what's in front of them. The mechanics of context, the work of context management, and auto-memory as a double-edged tool.
+
+### 5. [Building Your Harness](building-your-harness.md)
+
+The structure you build around the agent: AGENTS.md / CLAUDE.md, your own project skills, hooks, and the principles you hand to the agent as an explicit rubric. The harness is the actual tool; our skills are one ingredient.
+
+### 6. [When Things Go Sideways](when-things-go-sideways.md)
+
+Recognizing failure modes early. Getting unstuck, results that feel weird, context degradation, spotting a dumb-agent session. The bar for restarting is lower than you think.
+
+### 7. [The Outputs Are Yours](outputs-are-yours.md)
+
+Our skills produce files in your repo. You own them, version them, evolve them. Memory of what came before is your responsibility. Skills compose with your workflow, not the other way around.
+
+### 8. [Where Next?](where-next.md)
+
+Pointers outward: Antithesis docs and getting-started materials, your LLM tool's documentation, where to ask for help.

--- a/getting-started-documentation/building-your-harness.md
+++ b/getting-started-documentation/building-your-harness.md
@@ -1,0 +1,164 @@
+# Building Your Harness
+
+Your harness is what you put around an agent to make it useful for your project: AGENTS.md or CLAUDE.md, the skills you write or install, hooks that run automatically, rubrics you want the agent to follow. An agent comes general. Your harness makes it specific.
+
+You'll build your harness over time. Day one, you'll have nothing. Every time you correct the agent on something, every time you find yourself explaining the same thing twice, every time you wish a check happened automatically: put it in the harness. Once it's in, it sticks. Over time, you'll have a harness that fits your project.
+
+A lot of what you'll add to your harness over time is skills.
+
+## Skills
+
+Skills are commands in your agent: /antithesis-research, /antithesis-triage, /antithesis-workload. You invoke one, the agent does the thing. It looks like that's all there is to using them: invoke, get result, take what you get.
+
+There's more. A skill is information loaded into the agent's context for a particular kind of task. It's text in your filesystem, in markdown files you can open and read.
+
+That changes how you can use them. The default is to run a skill as-is: invoke it, the agent loads the text, the agent follows it. Most of the time that's exactly what you want. But it isn't the only way to work with them.
+
+You can take parts of a skill and use them in your own. Open the file. Copy what's useful. Use it in a skill you write.
+
+You can also use a skill outside what it was "designed for." Tell the agent to use the information from one skill for a task it wasn't "built around."
+
+> Using the analysis in antithesis-research, walk me through how requests flow when service A is down.
+
+> Looking at the failure modes catalogued in antithesis-research, where would be the riskiest place to introduce a code change next quarter?
+
+> Using the architecture analysis from antithesis-research, draft a one-pager I can share at next week's design review.
+
+> Make me a tutorial for my colleagues. Pull from antithesis-documentation and the other antithesis skills I have installed. Start with how Antithesis works, build up to good testing practices. Use our software as analyzed by antithesis-research for the worked example.
+
+The skill becomes context for whatever task you've got, not a fixed path you have to follow.
+
+## What the harness is for
+
+Agents lack taste. They've absorbed an enormous amount of code, but not the *whys* that led to those outputs. And the whys are what decide whether code is good. Good is partly intrinsic, mostly extrinsic: it depends on the system the code lives in, the constraints it has to satisfy, the trade-offs that were made. With the outputs but not the whys, agents produce code that looks correct without knowing whether it's appropriate. They cargo-cult patterns from elsewhere and don't probe for the constraints you're actually under: what the system needs to guarantee, what trade-offs you've already made, what failure modes you care about. Left to themselves, they build on whatever local context happens to fit, and over time that adds up to fragility.
+
+Architecture and design are still human work. The agent is a strong collaborator on implementation; it's a much weaker one on architecture. Your job is to inject the taste and domain knowledge it doesn't have. This is part of what the harness is for: the constraints, the conventions, the system's shape — encoded in your harness instead of held in your head and explained each session.
+
+Surfacing what's there to encode is its own task. When you're about to start something substantial, ask the agent up front:
+
+> Before we touch the code, let's talk about the constraints. What does this need to guarantee? What trade-offs have already been made? What are we trying to avoid?
+
+Anything from that conversation you'd repeat across sessions belongs in your harness. The question is where it goes.
+
+## Standing instructions
+
+Agentic tools read instruction files. CLAUDE.md for Claude Code, AGENTS.md for Codex. The agent loads them automatically at the start of every session. Whatever you put in them is in its context before it does anything.
+
+You can have these files at more than one level. A global file in your home directory applies to every session, in every project. A file at the root of a project applies to every session in that project. A file in a subdirectory applies when the agent is working in that subdirectory.
+
+Loading is additive. When you start a session and ask the agent to work somewhere, it pulls in your global file, the project's root file, and any subdirectory files that match where it's working. All of those contribute to the context the agent uses.
+
+Use the levels. Your global file is for principles and preferences you always want applied: code design rules, working-style preferences, things you never want the agent to do without asking. The project's root file is for conventions and facts about that specific project: its build commands, the directory layout, terms with specific meanings, things that differ from your usual habits. Subdirectory files refine that further when one part of your codebase has different rules.
+
+A global AGENTS.md might say:
+
+> Prefer explicit error handling over silent failures.
+> Don't make changes to my git history without asking.
+> When in doubt about scope, ask before acting.
+
+A project-root AGENTS.md might say:
+
+> Build with `make`. Tests run with `make test`.
+> All Antithesis-specific code lives under `antithesis/`. See `antithesis/AGENTS.md` for that directory's conventions.
+> "Workload" refers to the test workload we send to Antithesis, not generic "work."
+
+This is where to start building your harness. Put things in proactively when you know you want them applied. Put things in reactively when you find yourself repeating a correction.
+
+Each AGENTS.md is scoped to a location: global, project, or subdirectory. Within its scope, the agent always loads it. Some things don't fit any of those scopes.
+
+Take a deploy procedure. It's not universal: it's specific to this project. It's not tied to a single directory: deploy work might touch the whole repo. And it's not always relevant: you only deploy occasionally. Putting it in the project-root AGENTS.md would mean loading it every session: when you're writing tests, when you're refactoring, when you're triaging bugs. Most of the time it's noise.
+
+Things like that belong in a skill. Your release flow, your incident response, anything tied to a particular task lives in skills, not in AGENTS.md.
+
+## Writing your own skills
+
+Writing your own skills is easier than people expect. They're "just" text files. Markdown that lives on your machine and that the agent reads. Nothing more.
+
+People sometimes look at a skill, see how much instruction is in it, and assume writing one is a big undertaking. It doesn't have to be. The agent can help you write skills. Walk through what you want it to know. Ask it to draft the skill. Read what it gives you. Adjust where it got things wrong. That's most of writing a skill.
+
+Where you save the file determines who can use it. For your own work (debug workflows you've developed, shortcuts you've built), the skill lives in your home directory. In Claude Code that's `~/.claude/skills/`; other tools have similar conventions, check the docs. It's available to you in any project on the same machine.
+
+For a project's work (deploy procedures, release flows, incident runbooks, anything the team should do consistently), the skill lives in the project. Claude Code looks for project skills in `.claude/skills/` at the project root; other tools have similar conventions, check the docs. Commit it. Now anyone who clones the repo has the skill. Project skills are how harness content becomes shareable across a team.
+
+A skill has a few core parts: a name, a description that tells the agent when to use it, and the instructions themselves. The Claude Code or Codex docs cover the exact format your tool expects.
+
+The first version is rarely the last. As you use the skill, things turn up: steps that need clarifying, edge cases not covered, parts that aren't relevant after all. Update the skill. Over a few uses you'll know whether it's pulling its weight.
+
+Skills also tame variation. Some procedures need to be done the same way every time: your release process, your migration procedure, anything where a missed or out-of-order step causes real damage. The agent left alone isn't fully consistent across sessions. Even with the same prompt it might do things slightly differently. A skill removes that. The text becomes the spec.
+
+The best way to learn what good skills look like is to read ones other people wrote. Ours are open at [github.com/antithesishq/antithesis-skills](https://github.com/antithesishq/antithesis-skills). Read them. Lift parts into your own. Write your own that reference ours: invoke /antithesis-research as part of a bigger flow. Fork ours and pull updates periodically. Or use ours as inspiration and write something entirely your own.
+
+## Hooks
+
+Some agentic tools support hooks: scripts that fire automatically when certain events happen during the agent's work. A pre-tool hook fires before the agent invokes a particular tool. A post-edit hook fires after the agent edits a file. A session-start hook fires when a new session begins.
+
+Hooks are different from AGENTS.md and skills. Both of those are context the agent reads. The agent might act on what they say. It might not. LLMs are non-deterministic. An instruction in your AGENTS.md is something the agent should follow but isn't guaranteed to. A skill is something the agent should follow once invoked but again, isn't guaranteed to apply every step exactly.
+
+Hooks don't have that problem. When the trigger event fires, the script runs. Every time. Whether the agent wanted it to or not. That makes hooks the right choice for things you can't tolerate the agent skipping.
+
+What can you actually do with hooks? Here's a sample of what people use them for:
+
+- **Block bad commits.** A hook that runs before the agent commits, executing your test suite, your linter, your type checker first. If anything fails, the commit doesn't happen. The agent can't talk itself past a hook.
+- **Refuse destructive operations.** A hook that fires before shell commands run and scans for `rm -rf`, `git push --force` to main, `DROP TABLE`, anything irreversible. Block it or require explicit confirmation.
+- **Protect sensitive files.** A hook that fires before file edits and blocks them on specific paths: production config, credentials, generated code. The agent can read them but can't modify them.
+- **Inject context automatically.** A hook that fires at session start, runs `git status`, and injects the result into the agent's context, so it always knows what's uncommitted, what branch it's on, what state the working tree is in.
+- **Run formatters after edits.** A hook that runs after each file edit and applies Prettier, gofmt, rustfmt, whatever's appropriate. The code is consistent without the agent having to remember.
+- **Catch secrets before they leak.** A hook that runs before commits and scans for API keys, tokens, and credentials. The agent might not recognize what shouldn't go into a commit. The hook does.
+- **Log what the agent did.** A hook that runs after each tool use and records every shell command run, every file touched. Useful for after-the-fact review, debugging, or auditing.
+- **Warn about dangerous context.** A hook that fires at session start, checks if you're on the main branch, and warns you (or refuses to start a session there). Cheap way to keep accidental edits from landing.
+
+Claude Code's hook system has events for moments like these: before a tool runs, after a tool runs, before a prompt is submitted, at session start, when the agent stops. Other tools have similar hooks under different names. Your agent's docs cover what events its hooks can attach to.
+
+Hooks take more setup than a line in AGENTS.md. You're writing a script, choosing an event to attach it to, deciding what triggers a block. That cost is real, but for any rule you absolutely require, it buys you certainty. For everything else, AGENTS.md and skills are lighter weight.
+
+## Hand the agent its own rubric
+
+By now you've seen the components of a harness: AGENTS.md for what's always on, skills for task-specific work, hooks for what must happen, the capture-what-you-learn loop for keeping it growing. One of the most important things you can put into any of those is a rubric: your taste, written down.
+
+Agents have no taste. The "What the harness is for" section made this point: they've absorbed an enormous amount of code without absorbing the *whys* that decided which examples were any good. Without taste, they produce code that looks right but isn't appropriate. They cargo-cult patterns from elsewhere. They build whatever fits the local context.
+
+A rubric is the explicit version of taste. The principles you'd want any engineer working on your code to apply: error handling patterns, architectural preferences, style choices that aren't enforced by tools, the things you find yourself correcting people on. It's what you'd teach a new colleague over a few weeks of code review, written out so an agent can read it directly.
+
+Agents are good at following an explicit rubric. They're bad at inferring one from your reactions across a session. If you correct the agent for leaving dead code behind, the fix might stick for the rest of the session. Next session, the same agent makes the same mistake. You haven't taught it your taste. You've just course-corrected, again.
+
+What goes in a rubric? Taste calls. Things you want applied that your tools can't enforce. Patterns you find yourself correcting repeatedly. Examples:
+
+- "Prefer explicit error handling over silent failures."
+- "Don't add features, refactor, or introduce abstractions beyond what the task requires."
+- "Default to writing no comments. Only add one when the why is non-obvious."
+- "When you remove code, remove the tests for it too."
+- "Match the existing code style; don't restyle code you're modifying."
+
+These aren't facts about your project. They're judgments about what makes code worth shipping. Each one is what a careful reviewer would call out, written down so the agent applies it before a reviewer has to.
+
+Where the rubric lives depends on scope. Principles for all your work go in your global AGENTS.md. Project-specific principles go in the project's AGENTS.md. For principles that only matter for specific kinds of work, a separate file the agent reads on demand works better: "Apply the principles in PRINCIPLES.md to this change."
+
+Writing a rubric is harder than writing standing instructions, because it requires knowing what you care about. The first version will be short. As you work, you'll notice yourself reacting to the agent's output: "no, not like that" / "I'd never write it that way." Each of those reactions is a candidate for the rubric. The capture-what-you-learn loop is where the rubric grows.
+
+Your rubric does work everything else doesn't. AGENTS.md tells the agent what's true. Skills tell the agent how to do specific tasks. Hooks tell the agent what it can't get away with. The rubric tells the agent what good looks like. That shapes every line of code it writes.
+
+## Capture what you learn
+
+Your harness grows from what you notice while you work. Things you'd correct again. Decisions you reached. Conventions that emerged. The annoying tendencies that came up twice. If you don't capture them, they get lost.
+
+When the agent does something you don't like, don't just correct it and move on. Ask it why.
+
+> Why did you do it this way?
+
+The answer is often useful. Sometimes the agent reveals it didn't know about a constraint. Sometimes it shows you were ambiguous in a way you didn't notice. Sometimes it's working from an outdated assumption about your project. The information you get tells you where the gap is.
+
+Once you know why, ask what would have prevented it.
+
+> What would have stopped you from doing this? What could I add to my harness so this doesn't happen again?
+
+The agent has an opinion. Often a useful one. CLAUDE.md? A skill? A hook? A line in your rubric? Put the answer in your harness so you don't have to course-correct on the same thing twice.
+
+Same instinct at the end of a session. Ask the agent what came up that's worth keeping.
+
+> What did we learn in this session that we should capture so it doesn't get lost?
+
+You'll get back a mix: things you decided, conventions you settled on, gotchas you ran into, fixes you made. Pull what's worth keeping into your harness.
+
+Sometimes you don't need to ask. The pattern is clear from what just happened. Annoying behavior you've seen twice goes in your project instructions. A multi-step procedure you've walked the agent through more than once belongs in a skill. A constraint that should always hold goes in a hook. A taste call you keep making becomes a line in your rubric.
+
+You won't get the harness right on day one. You aren't supposed to. The point is to grow it deliberately from the things you actually notice.

--- a/getting-started-documentation/context-and-memory.md
+++ b/getting-started-documentation/context-and-memory.md
@@ -1,0 +1,43 @@
+# Context and Memory
+
+Agents work on the words in front of them: the files you've loaded, the prompts you've written, the conversation so far, the memory the tool has saved about you. What's there, what isn't, and what's been there too long all change the work. Understanding how the mechanism underneath actually works is one of the things that pays back most.
+
+## What a context window is
+
+The chat interface makes context look simple: you type, the agent responds, conversation continues. The mechanics underneath are different in ways that matter.
+
+Each prompt you send is a stateless request to the LLM. The model itself has no memory of your previous messages, no idea what you asked yesterday, no thread it's continuing. So how do conversations work?
+
+The answer is the context: with each new prompt, the agent re-sends what came before. Every previous message you wrote, every response the agent produced, every file it read, every tool it ran and the output it got back. All of it is part of the request to the LLM. Tools may compress older content as the window fills; when they do, the model sees a summary rather than the original. The model gets that bundle plus your new prompt and produces the next response. Then that response becomes part of the context for the next request. We can handwave and say the context is all the stuff that came before in the session, sent as part of each request, creating the illusion of continuity.
+
+The context window is the limit on how big that bundle can be. It's measured in tokens (the small pieces of text the model operates on). Every model has one. Modern windows are large (hundreds of thousands of tokens, sometimes millions) but they're not unlimited.
+
+This has consequences that aren't obvious from the chat interface. If you switch topics and come back, every message from the unrelated topic is still in the context for everything that follows. If you ask the agent to explore a codebase and it reads a thousand files before giving you a summary, the contents of all thousand files are in the context for the next request. Even if all you wanted was the summary.
+
+## Context Management
+
+Context management is on you. The window has limits, the model doesn't equally weight what's in it, and what you put there shapes everything the agent does.
+
+Bigger windows let you have longer sessions, hand the agent more files, reason over more material. They also degrade. Long sessions tend to produce sloppier work than short ones with the same starting prompt: the agent starts forgetting things you established earlier, repeating mistakes you corrected, taking longer to converge on simple answers.
+
+This isn't a bug to prompt around. Just because something is in the context doesn't mean the agent will actually apply it. LLMs are non-deterministic. The model doesn't apply every part of its context with equal force, and which parts it leans on can vary from run to run. The more that's in the window, the less attention each individual piece gets. The agent can effectively "forget" something that's right there in the context, not because the content is gone, but because it didn't get weighted heavily enough to matter.
+
+As the window fills, this compounds. Earlier content competes with newer content for the agent's attention; instructions you gave early can be ignored later; relevant details get crowded out by less relevant ones.
+
+The main lever is shaping. What goes into the agent's view determines what comes out. Which files you load, which prompt you write, which examples you point at do more work than most beginners realize. A short prompt with the right files in view will often produce better work than a long detailed prompt with too much context loaded. New users tend to either dump everything in (overload, the agent gets distracted) or load too little (the agent guesses). Find the middle: just enough to make the answer obvious.
+
+There's no fixed point where degradation starts. You develop a feel for it. As a rule of thumb: if a session has been going for a long time and is starting to feel less sharp than it did, you're probably running into degradation.
+
+When you notice it, you have a few options. Restart fresh, loading just what you actually need. Ask the agent to write a handoff document and start a new session with it loaded. Ask the agent whether it thinks the next round of work would go better in a fresh context. Or use your tool's context controls if it has them. There's a full discussion in the "[Context Degrading](when-things-go-sideways.md#context-degrading)" section of "[When Things Go Sideways](when-things-go-sideways.md)".
+
+## Auto-memory is double-edged
+
+Some agentic tools save facts across sessions. Claude Code calls this auto-memory; not every tool has it. The agent learns about your codebase, your conventions, your preferences over time, and brings that knowledge into future sessions. Powerful when it works. Costly when it doesn't.
+
+When it works, you save time. Things you've taught the agent stay taught. Conventions get followed without re-explanation. The agent feels like it's growing with your project.
+
+When it doesn't work, the memory has gone stale. A decision changes, a file moves, a convention evolves; the old memory persists, and the agent keeps acting on it. The agent's confidence about an outdated fact looks the same as its confidence about a current one. There's no surface signal that any particular piece of saved memory is outdated.
+
+For things that really matter (conventions you don't want forgotten, rules you don't want broken), don't rely on auto-memory at all. Codify them in your harness (skills, hooks, AGENTS.md, CLAUDE.md) where they live as version-controlled, explicit instructions. (See [Building Your Harness](building-your-harness.md).) Memory is a convenience; the harness is the source of truth.
+
+When you start getting results that feel weirdly wrong — the agent making decisions that don't match your current state, referring to things that don't exist anymore, applying a convention you stopped using, arguing with you about something you settled — check the auto-memory. Most tools let you inspect and edit memory directly. Outdated memory is one of the most confusing failure modes because nothing about the output looks wrong on its surface; the agent is "remembering" something, just the wrong thing. There's a full discussion in the "[Results Getting Weird](when-things-go-sideways.md#results-getting-weird)" section of "[When Things Go Sideways](when-things-go-sideways.md)".

--- a/getting-started-documentation/getting-oriented.md
+++ b/getting-started-documentation/getting-oriented.md
@@ -1,0 +1,38 @@
+# Getting Oriented
+
+This guide is a companion to our Antithesis skills. It isn't an introduction to Antithesis itself, and it isn't a step-by-step walkthrough of any one skill. It's about working productively with LLM agents (Claude Code, Codex, or whatever you're using) when you're using our skills to test your software with Antithesis.
+
+Read it through the first time; come back to chapters as you need them after that.
+
+## Who this is for
+
+We wrote this for engineers who:
+
+- **Have written code and tests before.** The kind of test most engineers have written (give some input, check the result) is our floor. With that experience comes the everyday vocabulary of software development: bug, triage, refactor, debug, and so on. You don't need property-based testing or anything more exotic. If "what's a test" is a real question for you, this isn't where to start.
+
+- **Have a basic familiarity with Antithesis and what you use it for.** You don't need to be an expert. You just need to have the basic shape in your head: what Antithesis does, why you'd reach for it, where it fits in how you build and test software. If that's not you yet, start at *[pointer to Antithesis intro]* before reading the rest of this guide.
+
+- **Have at least a vague mental model of what an LLM coding tool is.** You've chatted with an LLM somewhere (ChatGPT, Claude.ai in a browser, or similar). You don't need to have used an agentic tool yet; the guide is in part here to bridge from chatbot to agentic. If you've never used any LLM at all, try one in a browser first.
+
+- **Are comfortable enough on the command line.** The skills run inside terminal-based agents (Claude Code, Codex) and invoke other CLI tools: Docker, Snouty, and others. You don't need to be a sysadmin. You do need to be able to read an error message and look things up when something breaks. If the terminal is unfamiliar territory, this guide isn't where to start.
+
+If you're more experienced than the floor we just described, with months or years of using these tools, there's still plenty here for you. Skim, pick what's new, come back to specific chapters when something's biting you.
+
+If you're not at the floor on Antithesis or agentic tools yet, here's where to start:
+
+- **New to Antithesis?** Start at *[pointer to Antithesis intro]*. We'll touch on Antithesis concepts where we have to, but the real introduction lives elsewhere.
+- **Never used an agentic coding tool at all?** Start at your tool's own getting-started guide: *[Claude Code pointer]*, *[Codex pointer]*. Get the tool installed, try a small task or two, then come back here. Much of this guide lands harder without that first hands-on experience.
+
+## Vocabulary
+
+We define terms as we use them. The first time a term comes up, whether LLM-tool vocabulary or Antithesis-specific, we explain it then and there.
+
+For looking something up later, or refreshing a definition you've forgotten by the time you're deep in a chapter, the [Glossary](glossary.md) collects every term we use in one place.
+
+## How to use this guide
+
+Read it linearly the first time. The chapters build on each other: [The Right Mental Model](mental-model.md) sets the mindset that [Working with Your Agent](working-with-your-agent.md) makes operational; [Building Your Harness](building-your-harness.md) fleshes out concepts that earlier chapters touch on briefly.
+
+After that, treat it as a reference. When you hit a problem (the agent acting strangely, output that feels off, a session that won't converge), come back to the chapter that names what you're seeing. Each section is meant to stand on its own well enough that you don't have to reread everything before to make sense of it.
+
+We're not trying to be the only thing you read about working with LLM agents. We're trying to be the thing that gets you working productively with Antithesis skills specifically, with enough mental model that you can keep growing from here.

--- a/getting-started-documentation/glossary.md
+++ b/getting-started-documentation/glossary.md
@@ -1,0 +1,31 @@
+# Glossary
+
+Every term we define inline is collected here. LLM-tool vocabulary and Antithesis-specific terms are intermixed and alphabetized — if you forget where a definition was, look here first.
+
+**Agent.** An LLM that can do work — read files, write code, run commands — not just answer questions. When we say "your agent," we mean the active session in your tool.
+
+**AGENTS.md / CLAUDE.md.** A project-level instruction file that some agentic tools read on every session. AGENTS.md for Codex; CLAUDE.md for Claude Code. The contents apply across every session in the project without you having to repeat them.
+
+**Auto-memory.** A feature in some agentic tools (notably Claude Code) that saves facts about you, your project, and your preferences across sessions. Useful when it works; costly when it goes stale.
+
+**Context.** Everything the agent currently has in view: the conversation so far, the files it's loaded, the instructions it's been given. Context drives output.
+
+**Context window.** The finite amount of conversation the agent can attend to. Bigger windows allow longer sessions but degrade as they fill — sessions get sloppier the longer they run.
+
+**Ensemble methods.** Running the same task with multiple agents independently and comparing their results. Disagreement between runs flags areas that aren't well-grounded. Slower than single-pass work; more reliable.
+
+**Harness.** Everything you build around the agent to shape how it works on your project — project instructions, your own skills, hooks. Covered in depth in [Building Your Harness](building-your-harness.md).
+
+**Hook.** A script that fires automatically at certain points in the agent's work — for example, before a commit or after an edit. Hooks let you enforce guardrails the agent can't bypass.
+
+**Prompt.** What you type to the agent to start or continue a session — a question, an instruction, a paste of code, a goal description.
+
+**Rubric.** A set of principles or rules you want the agent to follow. You can hand the agent a rubric explicitly — for example, "apply the principles in PRINCIPLES.md" — instead of hoping it infers your preferences from corrections during the session.
+
+**Session.** One continuous conversation with the agent. Sessions accumulate context as you work and end when you close them or start a new one.
+
+**Skill.** A bundle of instructions the agent loads when needed for a specific kind of task. Our antithesis-* skills are examples. You can write your own.
+
+**Sub-agent.** An agent spawned by another agent — typically used so the spawning agent can have a fresh-context perspective review its own work.
+
+**Workload.** Code that drives activity in your system during an Antithesis test. Workloads exercise your system; Antithesis observes the behavior to detect failures.

--- a/getting-started-documentation/mental-model.md
+++ b/getting-started-documentation/mental-model.md
@@ -1,0 +1,57 @@
+# The Right Mental Model
+
+Most of the trouble people hit with LLM agents traces back to bringing the wrong mental model to the work. Get this part right and a lot of the rest is easier. Get it wrong and you'll spend most of your energy fighting symptoms.
+
+## They sound authoritative
+
+Agents almost always sound confident. They don't hedge unless you ask them to, and even then the hedging tends to get buried under more confident prose. "Here's the fix" reads the same whether the fix is right or a confident wrong guess.
+
+It might tell you to use a function that doesn't exist. It might assert a property of your codebase that isn't true. It might write a five-line explanation that contradicts how the system actually works. In each case the language is the same: same tone, same structure, same delivery as when the agent is correct. There's no surface signal that separates "I checked this and I'm right" from "this feels right and I'm telling you it's right."
+
+This isn't a quirk that better prompting fixes. LLMs work by predicting the next most likely token given what's come before. They produce plausible-sounding output, not verified output. Any individual answer should be treated as possibly wrong, including in ways the agent itself can't detect.
+
+This is a tone problem you have to compensate for. Assume the confidence is decorative, not informative. Correct answers and incorrect ones arrive with the same delivery; the difference between them lives in whether you check. There are ways to compensate: getting a second pair of eyes, running ensemble methods (multiple agents on the same problem, comparing their answers) for high-stakes work, shaping your harness (the instructions, skills, hooks, and rubrics you build around the agent) so the agent has the right context. We cover those in [Working with Your Agent](working-with-your-agent.md) and [Building Your Harness](building-your-harness.md).
+
+## Fallibility is a feature and a weakness
+
+LLM agents are non-deterministic. Two runs over the same prompt can produce different results. The same task can succeed cleanly one session and stumble the next.
+
+For programmers this feels wrong. We're trained on deterministic systems: give a function the same input and you get the same output, every time. That's reliability. Non-determinism reads as "broken" to that part of the brain.
+
+But the non-determinism isn't a flaw the LLM has to overcome. It's the source of the LLM's usefulness. A deterministic LLM would be a lookup table: same prompt, same canned answer, forever. What makes LLMs valuable is exactly that they give you something different each time: a different angle, a different solution path, a different framing of the problem. The variation is the engine.
+
+That cuts both ways. The variation that gives you new angles also gives you inconsistency: the same task that worked smoothly yesterday can stumble today. You can't replay the work the way you replay a unit test.
+
+Variation has to be managed, not relied on. A fresh session can see what a stale one missed. One agent can review another's work and find what neither would have alone. Those moves only work because the agents differ. For repeatable work where you need consistency, do the opposite: codify the process in a skill, a bundle of instructions the agent loads for a particular kind of task (see [Building Your Harness](building-your-harness.md)). Get used to variation.
+
+## Capability is uneven
+
+Working with an LLM agent isn't like working with a junior engineer who happens to know a lot. Their capability isn't a smooth gradient that maps to human experience. One moment it's debugging a complex concurrency problem; the next it's introducing simple logic bugs and changing the tests so they pass with the new incorrect logic.
+
+People new to LLMs get caught by this. The agent does something seemingly magical, and the natural inference is "this is a strong collaborator on hard problems." Then the next request — something simple — comes back wrong. Same agent. Same session. Different shape of task.
+
+You can't reliably reason about what an LLM will do well or poorly based on your intuition from working with people. The "idiot-savant junior engineer" framing helps you get started but stops being useful fast. The only reliable way to know how an agent will do on a task is to try it. This is part of why non-determinism matters: even your direct evidence from one attempt doesn't guarantee the next attempt will go the same way.
+
+As with confidence-without-correctness, the answer isn't to predict where the agent will fail. It's to compensate: get a second pair of eyes on work that matters, push back when something looks off, and use your harness to set guardrails for the failure modes you most care about. We cover those in [Working with Your Agent](working-with-your-agent.md) and [Building Your Harness](building-your-harness.md).
+
+## Collaborator, not oracle
+
+A common mistake new users make is treating an agent like a search engine that talks back. Ask, get answer, accept answer. That mental model gives you the worst version of what these tools can do. It stacks the costs of overconfidence, non-determinism, and uneven capability without taking advantage of any of the strengths.
+
+The frame that works better: you are working *with* a fast, broadly-knowledgeable collaborator who is sometimes wrong, sounds confident either way, and benefits from your judgment far more than from your obedience. When you bring that mindset, you ask follow-up questions. You push back. You redirect. You treat the first output as a starting point, not an answer. We cover the specific moves in [Working with Your Agent](working-with-your-agent.md).
+
+A collaborator who knows your project does better than one who walks in cold every session. The standing context that turns the agent from "knowledgeable stranger" into "teammate who knows the codebase" lives in [Building Your Harness](building-your-harness.md).
+
+Oracles return answers. Collaborators get worked with. You want the second one.
+
+## You're the pilot
+
+The agent doesn't know your codebase the way you do. It doesn't know your team's history, the bugs you've already chased, or the constraints you can't easily write down. It will happily charge in a direction with confidence, and if you don't steer, it will get a long way down the wrong road before you notice.
+
+You are responsible for the outcome. The agent is a tool you wield. That's not a complaint — it's the deal. Wield it well and you can do things that would otherwise be impractical. Don't, and you'll end up with a working-ish mess you don't understand.
+
+Part of being the pilot is the work the agent can't do for itself. You set the patterns. You make the architectural calls. You decide what's worth shipping. Agents produce plausible work; you decide whether it's the right work.
+
+Specifics on what piloting looks like in practice (when to push back, when to step in, when to start over) live in [Working with Your Agent](working-with-your-agent.md). The standing structure that supports piloting (rubrics the agent follows, hooks that catch things, project instructions that shape default behavior) lives in [Building Your Harness](building-your-harness.md).
+
+Steer often. Check in early. Don't let it run unattended for long stretches without looking at what it's doing.

--- a/getting-started-documentation/outputs-are-yours.md
+++ b/getting-started-documentation/outputs-are-yours.md
@@ -1,0 +1,43 @@
+# The Outputs Are Yours
+
+When one of our skills produces something — a research document, a workload, a triage report — it goes into your repo. From that point on, it's yours. We don't try to lock you into a workflow; we try to compose with whatever workflow you bring. That puts some responsibility on you for how those outputs live and evolve.
+
+## Compose with your workflow
+
+We don't prescribe how you fit the skills into your work. We aim to be workflow-agnostic, working with whatever conventions you have, including "I don't have any." It's a balancing act.
+
+The skills aren't a separate system you bolt on. They produce normal files in your repo. They go through your normal review process if you have one. They get tracked in whatever system you already use. There is no separate "Antithesis workflow" you need to adopt alongside what you already do.
+
+That extends to the artifacts themselves. If a default output location doesn't match how your repo is organized, move it. If the structure of a research document doesn't fit your conventions, edit it. If the naming convention clashes with your existing files, rename things.
+
+It also extends to the skills themselves. It's easy to think of a skill the way you'd think of a program: something opaque you invoke, that runs, that you can't change. Skills aren't that. A skill is text. Information loaded into the agent context to help it accomplish something. The process encoded in each of our skills is one way of doing the work, not *the* way. You can write your own skills that reference ours. You can lift parts of ours into your own. You can replace any of ours with your own.
+
+Your harness is where adjustments like these live. It's the layer you build around the agent: project-level instructions, skills you write yourself, hooks that run automatically. [Building Your Harness](building-your-harness.md) covers the mechanics. Once a convention's in your harness, every future session inherits it. The skill is a starting point, not a finished system.
+
+## Skills produce files in your repo
+
+Our skills produce outputs. Research documents, workload definitions, triage reports. They have to live somewhere, and by default they live in your repo. That's a default we picked, not a requirement.
+
+These are normal project files. You can version them, edit them, refactor them, delete them when they no longer apply. They aren't sacred. They aren't ours.
+
+## Memory of what came before is your responsibility
+
+Agents don't have memory. Each session starts from zero, with no recollection of what previous sessions did or learned. But research documents, triage reports, and workload definitions outlast the session that made them. That matters, because the next session benefits from what the last one knew.
+
+A research document you generate today describes your system in a way you'll keep coming back to: weeks later, when a colleague joins, when something breaks, when you're deciding what to test next. A triage report names bugs you found, and bugs cluster. When the next failure shows up, knowing what you found and what you tried last time is what keeps you from re-investigating ground you've already covered. Without something carrying that context forward, every session starts back at square one.
+
+The skills create some of these artifacts. You create more: notes about ongoing investigations, summaries of what was fixed and why, pointers to prior reports the next session should see.
+
+We don't mandate how. Git history is a strong substrate: commit messages, PR descriptions, merged branches become a queryable record of what was decided and why. A CHANGES file works. A notes directory works. Markdown in your harness works. Pick whatever fits your existing patterns. None of this is required. Skipping it doesn't break anything. But the experience is meaningfully better when the agent can pick up where the last session left off.
+
+## Research as a living document
+
+Research describes your whole system: what's there, how it fits together, what's worth testing and why. Other outputs are narrower in scope. A triage report is about a specific failure at a specific moment. A workload definition is about a specific test setup. Research is the map of the territory.
+
+That makes it the one most worth keeping current. A six-month-old research document describes a six-month-old system. Some things you tested then don't exist anymore. Some things you'd test now didn't exist when the research was written. The failure modes that mattered then aren't necessarily the ones that matter now.
+
+An agent reading the old document forms an outdated picture of your system. It asserts properties that no longer apply, probes failure modes that no longer matter, suggests tests for code that's been refactored away.
+
+Keep it current by re-running the skill when your system changes meaningfully, by editing the document directly as new things come up, or by some mix of the two. Running fresh after every change is one option, but it takes time and effort. Treating it as something you maintain by hand, with occasional re-runs, is often more practical. Pick the cadence that matches your project's pace of change.
+
+The document is yours. How it evolves is up to you.

--- a/getting-started-documentation/when-things-go-sideways.md
+++ b/getting-started-documentation/when-things-go-sideways.md
@@ -1,0 +1,69 @@
+# When Things Go Sideways
+
+Not every session goes well. The most useful skill at this stage is recognizing failure modes early and responding to them, rather than grinding harder. Most of the moves in this chapter boil down to: stop, change something, try again. The bar for restarting is lower than you think.
+
+If a session feels off, restart. If you can't quite say why but the work isn't landing, restart. If you've been course-correcting more than working, restart. Restarting is cheap. Salvaging a bad session is expensive. Bias toward restart, especially as you're learning. As you build calibration you'll get a better feel for when a session is recoverable; until then, the safe default is to start fresh.
+
+## Stuck and not making progress
+
+You asked. The agent tried. It didn't work. You pointed at what was wrong; the next version has a different problem. New round, new problem. Ten minutes in, the code's no better than when you started. Maybe worse, because there are more moving parts. Each round trades one problem for another, or restates the old problem in different words.
+
+Don't keep going. Change something: your prompt, your context, the files in view, the model, the session. Three failed attempts at the same approach is a signal to switch approaches, not to try harder.
+
+The cheapest move is often to ask the agent why it thinks it's failing — not "how do we fix this" but "what's your model of what's happening?" Sometimes the answer is the bug: the agent has been operating on a wrong assumption since turn one, and naming it makes the fix obvious. Sometimes it surfaces the wrong assumption *you've* been carrying. Either way, the loop breaks. An example of how that ask might sound:
+
+> We don't seem to be making progress. Let's stop what we are doing and figure out why we are stuck. What's your model of how this is supposed to work, and where do you think we're getting it wrong?
+
+## Results getting weird
+
+The agent acts on facts that aren't true anymore. References files that have moved. Applies conventions you stopped using. Argues with you about something you thought you settled last week. The output isn't wrong-looking on its surface. It just doesn't match your current reality.
+
+The cause is usually something in the agent's context. It could be auto-memory if your tool has it (Claude Code does; not every tool does). It could be a stale file you loaded earlier. It could be a line in your AGENTS.md or CLAUDE.md that hasn't been updated. The common factor: the agent is acting on stale information.
+
+Don't just correct the wrong claim and move on. Ask the agent why it thinks that — surface the source:
+
+> That's not true. Why do you think it is?
+
+The answer often points right at the stale source: an old memory, an outdated file, a line in your harness that hasn't been updated. Once you've found it, fix the source instead of correcting downstream every time.
+
+If the source is auto-memory, check what's saved and prune. Important constraints belong in your harness, not memory. The harness is version-controlled, so changes to it are visible. (See [Building Your Harness](building-your-harness.md).)
+
+## Context degrading
+
+Long sessions get worse. The agent forgets things you established. Repeats mistakes you corrected. Takes longer to converge on simple answers. This is a property of the technology, not something you can prompt around. Context windows fill up, and at some point the work the agent is doing starts to suffer for it.
+
+But context is also valuable. The files you've loaded, the decisions you've made together, the agent's working model of your problem — those are real. Walking away costs something. So the right move isn't always "just start over." It depends on how much you have in the session, and how much of it is worth preserving.
+
+Starting over isn't really losing work. The work is in your files. With a little effort, the context can live in your files too.
+
+A few approaches, in increasing order of effort:
+
+### Just restart
+
+If the session is short or the context isn't carrying much beyond what's in your files, start fresh and load what you need. The cheapest move; often the right one.
+
+### Hand off to a new session
+
+Ask the agent to write a handoff document (what you've decided, what's done, what's still open, what assumptions are in play) to a file. Then start a new session and feed it that file. You keep the decisions and lose the bloat. This is a generally useful technique because it works with any harness.
+
+> I want to continue this work in a new context. Write me a handoff document at HANDOFF.md. Include anything you think would be important to a new agent starting fresh including what we've decided, what we've finished, what's still open, and any assumptions. I'll start a new session and load it in.
+
+### Ask the agent whether to switch
+
+The agent often has a sense of when its own context is getting muddy. Asking is cheap.
+
+> Is this session still serving us? Would the next round of work go better in a fresh context?
+
+### Use your tool's context controls
+
+Some agentic tools let you hint at what to keep when context gets compacted (auto-summarization, manual pinning, and so on). The specifics are harness-dependent. Check what your tool offers. Most tools give you less control than you might want; that's why the handoff-document technique exists.
+
+## "Dumb agent" today
+
+Some sessions feel dumb. Users say it literally ("Claude feels dumb today") about an agent that was sharp yesterday and will be sharp tomorrow.
+
+There's no specific thing you can point at. That's the recognition. The interactions just don't feel as sharp as they usually do. You can't articulate what's wrong, exactly. You just feel it.
+
+This is different from being stuck (the agent circling a hard problem) and from results-getting-weird (the agent operating on a specific wrong claim). Dumb-agent doesn't have a "what's wrong" you can point at. It just is.
+
+Rewind to before the session went off and try again. Start fresh if rewinding doesn't help. Sometimes more context fixes it. Sometimes you just got an off run and a new session is the cure.

--- a/getting-started-documentation/where-next.md
+++ b/getting-started-documentation/where-next.md
@@ -1,0 +1,23 @@
+# Where Next?
+
+This guide has been about working with agents in the context of our skills. There's more to learn on both sides: about Antithesis itself, about the agentic tools you're using, and about the community of people doing this work.
+
+## Antithesis docs
+
+To learn what Antithesis is, how to run a test, or what the platform actually does, see [the Antithesis docs](https://antithesis.com/docs/).
+
+## LLM tool docs
+
+Whichever tool you're using has its own documentation. The parts about hooks, skills, and project instructions are worth reading even if you skim the rest. They shape what your harness can look like.
+
+For Claude Code: [docs.anthropic.com/en/docs/claude-code](https://docs.anthropic.com/en/docs/claude-code).
+
+For Codex: [developers.openai.com/codex](https://developers.openai.com/codex).
+
+## Where to ask for help
+
+Agents are good but they aren't the only resource.
+
+For general questions and discussion, join the [Antithesis Discord](https://discord.gg/antithesis).
+
+For suspected bugs or feedback on the skills specifically, file a [GitHub issue](https://github.com/antithesishq/antithesis-skills/issues).

--- a/getting-started-documentation/working-with-your-agent.md
+++ b/getting-started-documentation/working-with-your-agent.md
@@ -1,0 +1,101 @@
+# Working with Your Agent
+
+Mental model is the foundation. This chapter is the mechanics: the moves you'll make over and over as you actually do work with an agent. Some of these will feel unnatural at first because the interface looks transactional. It isn't. The earlier you internalize that, the more you'll get out of these tools.
+
+## Talk to it like a teammate
+
+You hand the agent three documents and say "make me a report." What you get back isn't what you wanted. Surprising? Not really. You didn't tell it what you wanted.
+
+This isn't an LLM-specific problem. A human teammate handed the same three documents with the same one-line instruction is equally unlikely to produce what you want. They don't know what you're going to use it for, who the audience is, what's already been decided, or which parts you care about. They'd guess, pick a safe path, and deliver something that technically meets the brief.
+
+The fix is the same with the agent as it is with the teammate: tell it the things they need to know. What you're trying to accomplish. Who's going to read it. What you're worried about. What you've already considered and ruled out. What good would look like.
+
+The frame: treat the agent as a teammate, not a servant. A servant takes commands and runs with them; a teammate shares context and pushes back. The agent does its best work as the second one.
+
+## Ask the agent about the agent
+
+Claude knows a lot about Claude. Codex knows a lot about Codex. Each agent's knowledge of how its tool works (features, quirks, harness mechanisms) is sitting there waiting for you to use.
+
+If you don't know how to do something with the tool itself (write a skill, tune a hook, structure your project instructions), ask. The reflexive move is to go to the docs; often it's faster to ask the agent first.
+
+When a session goes badly, ask the agent for a retrospective. It often has a sharper sense of what went wrong than you do.
+
+> Looking back at this session, what got in the way? What would have made it go more smoothly?
+
+Same trick for the long game: when you find yourself correcting the agent on the same thing repeatedly, ask how to bake the correction into your harness. CLAUDE.md? A skill? A hook? The agent knows your tool's mechanisms better than most users do.
+
+## Iterate small
+
+Don't try to one-shot. Tell the agent the first step. Look at what it did. Tell it the next step. Yes, you can ask it to do more in one shot. Sometimes that works. But one-shot has an asymmetry: the longer the agent runs, the more depends on what it did early. A wrong call near the end is cheap to fix. A wrong call near the start — the agent picks the wrong abstraction, gets the data model wrong, sets up a bad invariant — and everything built on top has to be unwound. Frequent check-ins keep you close to those foundational decisions, where the cost of correction is still small.
+
+This is the classic "go slow to go fast." Three small loops are usually cheaper than one long loop that drifted. The bias toward small loops feels slower in the moment; it's usually faster overall.
+
+What counts as "small" will vary. Early in your experience with these tools, "small" should be baby steps. You're still learning the agent's failure modes and your harness is bare. As you get more experience and your harness fills out, "small" can grow. The corrections you've baked into your harness live in the agent's context already, so the agent doesn't make those mistakes as often. Start conservative; let the size grow as both develop.
+
+## The patcher
+
+Agents love to patch. A bug shows up in function X; the agent adds a special case to X. Another bug appears; another special case. A few rounds of this and you have a Jenga tower of special-cased fixes that nobody will be able to safely modify in six months.
+
+This happens because agents don't naturally step back. They focus on the local problem in front of them (the bug, the test, the request) and apply a local fix. Stepping back to see the pattern has to come from you.
+
+When you notice you've patched the same area more than a few times, stop and ask for a refactor.
+
+> This is the third patch in this area. Should we refactor?
+
+Or, more directly: "Look at this code and tell me if there's a better structure." The agent is good at executing a refactor: moving code, restructuring. The design call, what to refactor and how, is yours. It won't propose the refactor unprompted, and won't notice the structural pattern from the inside.
+
+The deeper move is to set things up so the agent has the design context it needs from the start: constraints, conventions, the system's actual shape. That belongs in your harness. (See [Building Your Harness](building-your-harness.md).)
+
+This isn't optional. Without it, agent-assisted code accumulates fragility.
+
+## Pushback as a primary mode
+
+There's a middle ground between "accept what the agent gave you" and "throw it out and start over." But that middle has a danger: muddling. Telling the agent "try again" or "that doesn't seem right, can you do something else" puts you in the middle without giving the agent anything new to work with. You're rejecting the answer without pointing at why or what's wrong. Three rounds of that and you're no closer than when you started.
+
+Pushback is the productive form of being in the middle. It has a shape: it points in a direction. "That doesn't account for [the constraint we just discussed]." "What happens if [X] happens?" "Why did you choose X over Y?" "I don't think that's right because Z." Each one says something specific the next answer should address. And it's the move you should use the most.
+
+You don't have to know exactly what's wrong to push back. "Something about this feels off — I'm not sure what" is a perfectly valid move. The agent will often surface what it might be:
+
+> Something about this feels wrong but I'm not sure what. Can you walk through your reasoning and flag anywhere you weren't confident?
+
+And don't be afraid to be wrong. Pushback isn't adjudication. Sometimes you push back and the agent explains why your concern doesn't apply, and you learn something. That's still a win.
+
+## You can step in
+
+When the agent is going in circles or making something worse, you don't have to ask it to fix the problem. You can read the code yourself. You can edit the file. The agent isn't a separate authority. It's a partner, and partners hand things back and forth.
+
+What stepping in looks like varies. Sometimes it's reading the code to see what the agent isn't seeing. Sometimes it's writing a small example of what you want and saying "do it like this." Sometimes it's just doing the thing. The trigger is usually the same: the next prompt would cost more than just handling it yourself.
+
+When you do step in, tell the agent what you did. Agents don't always re-read files between turns. They often work from what's already in their context. If you change a file and don't tell the agent, the next thing it does may be based on the stale version it remembers. Worst case: it overwrites what you just changed.
+
+> I edited X to do Y. Please re-read it before continuing. Let's keep going from there.
+
+New users default to asking the agent. They don't have to.
+
+## Use a second pair of eyes
+
+Whether or not you think your agent has done a good job, get another agent to look at the output. This is the same instinct you'd apply with a human teammate: ask a colleague to read what you wrote or eyeball your design, even when you think it's solid. Hand the work to someone who didn't help produce it, agent or human, and they see what you can't.
+
+What makes a fresh reviewer valuable, agent or human, is the lack of shared context. The original work had assumptions baked in: about the problem, the approach, the trade-offs you decided early. You and the agent that produced the work share those assumptions, including potentially flawed ones. A reviewer who doesn't have them reads the result on its own terms and notices things that became invisible to you and the original agent.
+
+> Here's a piece of work. I want a fresh read on it: strengths, weaknesses, anything that looks suspect.
+
+How you get the fresh eyes varies. Some people ask the current agent to spawn a sub-agent (a child agent run that returns its result to the parent). Some open a new session, sometimes with a different model or harness. Whatever you do, give the reviewer the same kind of setup you'd give a human: the work itself, plus the supporting material that helps make sense of it (relevant constraints, design docs, the "we decided X because Y" notes). Skip the conversation that produced the work, though. That carries the same assumptions you want fresh eyes to escape.
+
+What this costs depends on what you ask of it. A sub-agent reviewing a small piece of work returns quickly. A fresh session asked to review a sprawling change with all the supporting documentation is expensive in both time and tokens. Either way, the technique is effective.
+
+## Ensemble methods
+
+Ensemble methods involve running the same task through multiple agents independently (each agent works on the problem without seeing what the others produced) and then comparing the resulting answers. The independence is essential: if one agent sees what another said, the second one anchors on it and you lose the diversity of perspective that makes the technique work.
+
+What "multiple agents" looks like in practice varies. It might be several sessions of the same model run in parallel. It might be different models tackling the same task. It might be entirely different harnesses producing different framings of the question. The point is that each one approaches the problem fresh.
+
+When you compare the results, you look for two things. Where they converge (multiple independent agents arriving at the same answer), you have higher confidence the answer is well-grounded. Where they diverge, you've found places that need more attention before trusting any single answer.
+
+How you actually do the comparison varies. For a few answers, you can read them yourself and form a synthesis. For more, it's often worth handing the answers to another agent: to integrate them into a final answer, to flag where they disagree, or to pick the best of the bunch. The `antithesis-research` skill is a working example of the pattern: multiple evaluators run independently, then a synthesis stage integrates their findings. Worth a read if you want to see ensemble in action.
+
+Ensemble works best for tasks where there's genuine room for the answer to be wrong: design proposals, code reviews, bug-finding, evaluating tradeoffs. It doesn't help with mechanical tasks where the answer either is or isn't.
+
+This is the structured form of the same principle as *Use a second pair of eyes*: independent perspectives catch what shared perspectives miss. The difference: second-pair-of-eyes gets one fresh reviewer of finished work; ensemble has several agents do the work in parallel from the start, and compares where their answers agree and disagree.
+
+Ensemble costs more than a single run: more time, more tokens, more sessions to manage. What you get for that cost is catching things any single agent (yours included) would miss. Use it for work where being right matters more than being fast.


### PR DESCRIPTION
A companion guide for users of the Antithesis skills who are working with LLM agents (Claude Code, Codex, or similar). Covers what the skills themselves do not: mental model for working with agents, day-to-day working patterns, context and memory, building up a harness over time, recognizing failure modes, and how to think about the outputs.

Adds a "Working with LLM agents" section to the README pointing readers to the guide.

Eight chapters plus a glossary:
1. Getting Oriented
2. The Right Mental Model
3. Working with Your Agent
4. Context and Memory
5. Building Your Harness
6. When Things Go Sideways
7. The Outputs Are Yours
8. Where Next?

The guide has been through a multi-persona voice review (Voice, Narrative, Orientation, Tightness, Content-honesty) with fixes applied where the right change was clear and parked items resolved with Sean.

The "[pointer to Antithesis intro]" / "[Claude Code pointer]" / "[Codex pointer]" placeholders in Chapter 1 are intentional — the inline-definition and intro-link pass is deferred to pre-publication.