### PR TITLE
docs: scope the antithesis-workload example prompt to a single property

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Here's an example:
 ### antithesis-workload
 
 ```
-/antithesis-workload Review the plan for testing with Antithesis in @antithesis/scratchbook/property-catalog.md and implement the workload.
+/antithesis-workload Review the plan for testing with Antithesis in @antithesis/scratchbook/property-catalog.md and implement a workload for a single property to start.
 ```
 
 This skill implements Antithesis workloads and places all the test commands and supporting files under `antithesis/test/`, adds assertions to carefully chosen locations in the SUT.


### PR DESCRIPTION
The README's example prompt for `antithesis-workload` said "implement the workload," which primes the agent to implement the whole property catalog in one pass. That fights the workload skill's own guidance: it recommends implementing one property at a time, starting with a simple one to validate the harness end-to-end before going broad (`antithesis-workload/SKILL.md:60,66`).

This scopes the example prompt to a single property to start, so the suggested prompt matches how the skill actually works.