### PR TITLE
fix: update Antithesis doc links after docs site reorg

### DIFF
--- a/antithesis-documentation/SKILL.md
+++ b/antithesis-documentation/SKILL.md
@@ -59,8 +59,8 @@ Always add the `.md` extension before requesting files from `https://antithesis.
 
 Examples:
 
-- `https://antithesis.com/docs/using_antithesis/sdk/go/` becomes `https://antithesis.com/docs/using_antithesis/sdk/go.md`
-- `/using_antithesis/sdk/go/` becomes `https://antithesis.com/docs/using_antithesis/sdk/go.md`
+- `https://antithesis.com/docs/reference/sdk/go/` becomes `https://antithesis.com/docs/reference/sdk/go.md`
+- `/reference/sdk/go/` becomes `https://antithesis.com/docs/reference/sdk/go.md`
 
 Exceptions:
 

--- a/antithesis-research/SKILL.md
+++ b/antithesis-research/SKILL.md
@@ -52,10 +52,10 @@ If scratchbook artifacts already exist, treat them as inputs and extend them ins
 
 Use the `antithesis-documentation` skill to ground Antithesis-specific terminology and implementation advice.
 
-- Properties and assertions: `https://antithesis.com/docs/properties_assertions/assertions.md`
-- Sometimes assertions: `https://antithesis.com/docs/best_practices/sometimes_assertions/`
-- Define test properties: `https://antithesis.com/docs/using_antithesis/sdk/define_test_properties/`
-- SDK runtime modes and production behavior: `https://antithesis.com/docs/using_antithesis/sdk/`
+- Properties and assertions: `https://antithesis.com/docs/concepts/properties_assertions/assertions.md`
+- Sometimes assertions: `https://antithesis.com/docs/concepts/properties_assertions/sometimes_assertions.md`
+- Define test properties: `https://antithesis.com/docs/reference/sdk/define_test_properties.md`
+- SDK runtime modes and production behavior: `https://antithesis.com/docs/reference/sdk.md`
 - Optimize for testing: `https://antithesis.com/docs/best_practices/optimizing.md`
 
 ## Reference Files

--- a/antithesis-research/references/faults.md
+++ b/antithesis-research/references/faults.md
@@ -72,7 +72,7 @@ per-container rule). Low-level intrinsics like `__rdtsc()` are unaffected.
 
 Thread pausing
 : Individual threads are paused briefly, causing unexpected interleavings.
-Requires [instrumentation](https://antithesis.com/docs/instrumentation/coverage_instrumentation/).
+Requires [instrumentation](https://antithesis.com/docs/reference/instrumentation/coverage_instrumentation.md).
 
 CPU modulation
 : The simulated processor clock speed and instruction-level performance

--- a/antithesis-setup/SKILL.md
+++ b/antithesis-setup/SKILL.md
@@ -54,12 +54,12 @@ Success means:
 
 Use the `antithesis-documentation` skill to access these pages. Prefer `snouty docs`.
 
-- Docker Compose setup guide: `https://antithesis.com/docs/getting_started/setup/`
-- Docker best practices: `https://antithesis.com/docs/best_practices/docker_best_practices/`
-- Coverage instrumentation: `https://antithesis.com/docs/instrumentation/coverage_instrumentation/`
-- Assertion cataloging: `https://antithesis.com/docs/instrumentation/assertion_cataloging/`
-- Handling external dependencies: `https://antithesis.com/docs/reference/dependencies/`
-- Fault injection: `https://antithesis.com/docs/environment/fault_injection/`
+- Docker Compose setup guide: `https://antithesis.com/docs/getting_started/setup_guide/docker_compose.md`
+- Docker best practices: `https://antithesis.com/docs/best_practices/docker_best_practices.md`
+- Coverage instrumentation: `https://antithesis.com/docs/reference/instrumentation/coverage_instrumentation.md`
+- Assertion cataloging: `https://antithesis.com/docs/reference/sdk/assertion_cataloging.md`
+- Handling external dependencies: `https://antithesis.com/docs/reference/dependencies.md`
+- Fault injection: `https://antithesis.com/docs/concepts/fault_injection.md`
 
 ## Workflow
 

--- a/antithesis-setup/references/instrumentation.md
+++ b/antithesis-setup/references/instrumentation.md
@@ -121,5 +121,5 @@ If instrumentation is missing in the report, fix the image contents or build fla
 
 ## Documentation Grounding
 
-- Coverage instrumentation: `https://antithesis.com/docs/instrumentation/coverage_instrumentation/`
-- Assertion cataloging: `https://antithesis.com/docs/instrumentation/assertion_cataloging/`
+- Coverage instrumentation: `https://antithesis.com/docs/reference/instrumentation/coverage_instrumentation.md`
+- Assertion cataloging: `https://antithesis.com/docs/reference/sdk/assertion_cataloging.md`

--- a/antithesis-setup/references/language/cpp.md
+++ b/antithesis-setup/references/language/cpp.md
@@ -2,7 +2,7 @@
 
 First, use the `antithesis-documentation` skill to load the latest Antithesis docs for C/C++ instrumentation before applying this guidance.
 
-- `https://antithesis.com/docs/using_antithesis/sdk/cpp/instrumentation/`
+- `https://antithesis.com/docs/reference/sdk/cpp/instrumentation.md`
 
 You MUST use the latest version of the Antithesis C/C++ SDK. To lookup the latest version, load `https://api.github.com/repos/antithesishq/antithesis-sdk-cpp/tags` and find the tag representing the latest version.
 

--- a/antithesis-setup/references/language/dotnet.md
+++ b/antithesis-setup/references/language/dotnet.md
@@ -2,7 +2,7 @@
 
 First, use the `antithesis-documentation` skill to load the latest Antithesis docs for .NET instrumentation before applying this guidance.
 
-- `https://antithesis.com/docs/using_antithesis/sdk/dotnet/instrumentation/`
+- `https://antithesis.com/docs/reference/sdk/dotnet/instrumentation.md`
 
 You MUST use the latest version of the Antithesis .NET SDK. To look up the latest version, load `https://api.nuget.org/v3-flatcontainer/antithesis.sdk/index.json` and use the last entry in the `versions` array.
 

--- a/antithesis-setup/references/language/fallback.md
+++ b/antithesis-setup/references/language/fallback.md
@@ -6,9 +6,9 @@ Use this reference for any language that does not have a first-class Antithesis 
 
 First, use the `antithesis-documentation` skill to load the latest Antithesis docs relevant to the fallback SDK.
 
-- `https://antithesis.com/docs/using_antithesis/sdk/fallback/`
+- `https://antithesis.com/docs/reference/sdk/fallback.md`
 
-You MUST use the latest fallback SDK schema and message format. To look it up, load `https://antithesis.com/docs/using_antithesis/sdk/fallback/schema/` and follow the current schema there.
+You MUST use the latest fallback SDK schema and message format. To look it up, load `https://antithesis.com/docs/reference/sdk/fallback/schema.md` and follow the current schema there.
 
 The fallback SDK path works for any language because it relies on writing JSONL messages to Antithesis rather than linking a language-native SDK.
 

--- a/antithesis-setup/references/language/go.md
+++ b/antithesis-setup/references/language/go.md
@@ -2,7 +2,7 @@
 
 First, use the `antithesis-documentation` skill to load the latest Antithesis docs for Go instrumentation before applying this guidance.
 
-- `https://antithesis.com/docs/using_antithesis/sdk/go/instrumentor/`
+- `https://antithesis.com/docs/reference/sdk/go/instrumentor.md`
 
 You MUST use the latest version of the Antithesis Go SDK. To look up the latest version, load `https://proxy.golang.org/github.com/antithesishq/antithesis-sdk-go/@latest` and use the returned `Version`; use that same version for `antithesis-go-instrumentor`.
 

--- a/antithesis-setup/references/language/java.md
+++ b/antithesis-setup/references/language/java.md
@@ -2,7 +2,7 @@
 
 First, use the `antithesis-documentation` skill to load the latest Antithesis docs for Java instrumentation before applying this guidance.
 
-- `https://antithesis.com/docs/using_antithesis/sdk/java/how_to_build_with_sdk/`
+- `https://antithesis.com/docs/reference/sdk/java/how_to_build_with_sdk.md`
 
 You MUST use the latest version of the Antithesis Java SDK. To look up the latest version, load `https://repo.maven.apache.org/maven2/com/antithesis/sdk/maven-metadata.xml` and use the `<release>` value.
 

--- a/antithesis-setup/references/language/javascript.md
+++ b/antithesis-setup/references/language/javascript.md
@@ -2,7 +2,7 @@
 
 First, use the `antithesis-documentation` skill to load the latest Antithesis docs for JavaScript instrumentation before applying this guidance.
 
-- `https://antithesis.com/docs/using_antithesis/sdk/javascript_sdk/`
+- `https://antithesis.com/docs/reference/sdk/javascript_sdk.md`
 
 There is no Antithesis JavaScript SDK. For JavaScript projects, use the fallback SDK for assertions and lifecycle by following `references/language/fallback.md`.
 

--- a/antithesis-setup/references/language/python.md
+++ b/antithesis-setup/references/language/python.md
@@ -2,7 +2,7 @@
 
 First, use the `antithesis-documentation` skill to load the latest Antithesis docs for Python instrumentation before applying this guidance.
 
-- `https://antithesis.com/docs/using_antithesis/sdk/python/`
+- `https://antithesis.com/docs/reference/sdk/python.md`
 
 You MUST use the latest version of the Antithesis Python SDK. To look up the latest version, load `https://pypi.org/pypi/antithesis/json` and use `info.version`.
 

--- a/antithesis-setup/references/language/rust.md
+++ b/antithesis-setup/references/language/rust.md
@@ -2,8 +2,8 @@
 
 First, use the `antithesis-documentation` skill to load the latest Antithesis docs for Rust integration before applying this guidance.
 
-- `https://antithesis.com/docs/using_antithesis/sdk/rust/`
-- `https://antithesis.com/docs/using_antithesis/sdk/rust/instrumentation/`
+- `https://antithesis.com/docs/reference/sdk/rust.md`
+- `https://antithesis.com/docs/reference/sdk/rust/instrumentation.md`
 
 You MUST use the latest version of both Antithesis Rust crates. To look up the latest versions, load the crates.io API and use `crate.max_stable_version`:
 

--- a/antithesis-workload/SKILL.md
+++ b/antithesis-workload/SKILL.md
@@ -92,10 +92,10 @@ Ask the user only for blockers or scoping decisions you cannot infer safely, suc
 
 Use the `antithesis-documentation` skill to access these pages. Prefer `snouty docs`.
 
-- Test commands reference: `https://antithesis.com/docs/test_templates/test_composer_reference.md`
-- SDK reference: `https://antithesis.com/docs/using_antithesis/sdk.md`
-- Properties and assertions: `https://antithesis.com/docs/properties_assertions/assertions.md`
-- Fault injection: `https://antithesis.com/docs/environment/fault_injection.md`
+- Test commands reference: `https://antithesis.com/docs/product/test_templates/test_composer_reference.md`
+- SDK reference: `https://antithesis.com/docs/reference/sdk.md`
+- Properties and assertions: `https://antithesis.com/docs/concepts/properties_assertions/assertions.md`
+- Fault injection: `https://antithesis.com/docs/concepts/fault_injection.md`
 
 ## Reference Files
 


### PR DESCRIPTION
The Antithesis docs reorganized their URL structure under new `concepts/`, `reference/`, and `product/` prefixes, which 404'd the markdown (`.md`) doc links referenced across several skills. This repoints every affected link to its current location, resolved via the docs' own redirect map and cross-checked against `llms.txt`.

It also converts the remaining agent-facing HTML doc links in the research and setup skills (and their reference assets) to the markdown versions, so agents fetch markdown directly. Human-facing prose links in the README and getting-started guides, along with the `antithesis-documentation` skill's illustrative URL examples, are intentionally left as HTML page URLs.

`make validate-links` passes clean.