### PR TITLE
Update antithesis-setup to use explicitly use antithesis-launch rather than snouty launch

### DIFF
--- a/antithesis-setup/SKILL.md
+++ b/antithesis-setup/SKILL.md
@@ -88,7 +88,7 @@ This skill is broken out into multiple steps, each in a different reference file
   complete until the relevant images expose `/opt/antithesis/catalog/` or
   `/symbols/` correctly for their language.
 - Treat local testing as required before the first submission.
-- Use `snouty launch` directly to submit runs. Run `compose build` before `snouty launch` to ensure images are up to date.
+- Use the `antithesis-launch` skill to submit runs, do not run `snouty launch` directly. If the `antithesis-launch` skill is not present, then use `snouty launch` directly to submit runs. Run `compose build` before `snouty launch` to ensure images are up to date.
 - Do not add a separate Dockerfile under `antithesis/config/` unless the
   deployment explicitly requires it.
 - Disable color/ANSI output in every container. Antithesis stores raw bytes and

--- a/antithesis-setup/references/docker-compose.md
+++ b/antithesis-setup/references/docker-compose.md
@@ -24,7 +24,7 @@ Do not use underscores in `hostname` or `container_name` — underscores are not
 
 Services use one of two patterns:
 
-- **Local images** use `build:` with a context path and `image:` with `name:tag`. Build these before invoking `snouty launch`.
+- **Local images** use `build:` with a context path and `image:` with `name:tag`. Build these before invoking `antithesis-launch` or `snouty launch`.
 - **Public images** use `image:` directly (e.g. `docker.io/library/postgres:17.2`).
 
 Every service must include `platform: linux/amd64` because Antithesis runs on x86-64. This applies to both local and public images — without it, builds and pulls on ARM hosts (e.g. macOS Apple Silicon) will produce the wrong architecture.

--- a/antithesis-setup/references/instrumentation.md
+++ b/antithesis-setup/references/instrumentation.md
@@ -38,7 +38,7 @@ Write the result down in the Antithesis notebook when the answer is non-obvious.
 
 - Instrument the actual binaries or runtime artifacts that will execute inside Antithesis, not an unrelated local build output.
 - Install the language-appropriate Antithesis SDK into the dependency graph of the code that will emit assertions or lifecycle events.
-- Build and validate instrumentation before the first `snouty launch`.
+- Build and validate instrumentation before running `antithesis-launch` or `snouty launch`.
 - If you add assertions later, rerun the relevant instrumentor or rebuild path so assertion cataloging stays current.
 - If a language relies on `/opt/antithesis/catalog/`, avoid symlink chains deeper than one hop inside that tree.
 - If a language relies on `/symbols`, place the files in the image that contains the instrumented software.

--- a/antithesis-setup/references/submit-and-test.md
+++ b/antithesis-setup/references/submit-and-test.md
@@ -2,6 +2,10 @@
 
 How to test locally and submit to Antithesis.
 
+## Defer to using `antithesis-launch`
+
+Use the `antithesis-launch` skill to kick off a run. That skill should handle all that's needed to kick off a run with Antithesis. If for some reason, the `antithesis-launch` skill is not present, fall back to using the steps listed below.  
+
 ## Local Testing First
 
 Before submitting to Antithesis, test locally:


### PR DESCRIPTION
Update the `antithesis-setup` skill to use `antithesis-launch` rather than `snouty launch` directly. Cleaning up some discrepancies.