### PR TITLE
Research: validate external claims before building on them

### DIFF
--- a/antithesis-research/SKILL.md
+++ b/antithesis-research/SKILL.md
@@ -27,7 +27,7 @@ At the start of every research run, ask the user about external references:
 
 > Before I start, are there docs, design notes, related repos, issue trackers, or anything else outside this directory tree that I should also consult? "Just this directory" is fine.
 
-Capture the answer verbatim. Each external reference becomes a `path` (or URL) plus a brief `why` note. The orchestrator (this skill) holds the answer for the full duration of the run and threads it as input to every reference workflow that produces a top-level artifact: `sut-discovery.md`, `sut-analysis.md`, `property-discovery.md`, `deployment-topology.md`, `property-evaluation.md`. Each of those references' agent-instruction sections accepts the list as input. The list is also recorded in the provenance frontmatter of every top-level artifact (see `references/scratchbook-setup.md`).
+Capture the answer verbatim. Each external reference becomes a `path` (or URL) plus a brief `why` note. The orchestrator (this skill) holds the answer for the full duration of the run and threads it as input to every reference workflow that produces a top-level artifact: `sut-discovery.md`, `sut-analysis.md`, `property-discovery.md`, `deployment-topology.md`, `property-evaluation.md`. Each of those references' agent-instruction sections accepts the list as input. The list is also recorded in the provenance frontmatter of every top-level artifact (see `references/scratchbook-setup.md`). Any agent that receives the external references treats each as a lead to validate, not a fact — see `references/validating-claims.md`.
 
 Beyond the scope question, ask only for blockers or scoping decisions you cannot infer safely:
 
@@ -67,6 +67,7 @@ Use the `antithesis-documentation` skill to ground Antithesis-specific terminolo
 | `references/sut-analysis.md`        | General methodology for analyzing the codebase and understanding components |
 | `references/property-discovery.md`  | Discovering properties through structured attention focuses |
 | `references/property-catalog.md`    | Format and methodology for documenting properties   |
+| `references/validating-claims.md`   | How to treat claims from docs and issues — validate before building on them |
 | `references/faults.md`              | Understanding fault types, quiet periods, and process fault availability |
 | `references/deployment-topology.md` | Designing the container topology for Antithesis     |
 | `references/property-evaluation.md` | Evaluating the property catalog as a portfolio       |
@@ -101,7 +102,7 @@ Use the `antithesis-documentation` skill to ground Antithesis-specific terminolo
 1. Read `references/sut-discovery.md` and `references/sut-analysis.md` if the system model is missing or stale
 2. Read `references/property-discovery.md` and `references/property-catalog.md`
 3. Discover properties using the ensemble or single-agent workflow from `references/property-discovery.md`
-4. Turn claimed guarantees, incidents, and bug reports into explicit properties, and choose the Antithesis assertion type that matches each one
+4. Turn claimed guarantees into explicit properties. For incidents and bug reports, confirm the reported defect is a real system defect before making it a property (see `references/validating-claims.md`). Choose the Antithesis assertion type that matches each one
 5. Update `antithesis/scratchbook/property-catalog.md` and record assumptions or open questions
 6. Write evidence files for new properties to `antithesis/scratchbook/properties/{slug}.md`
 7. Update `antithesis/scratchbook/property-relationships.md` with any new clusters or connections
@@ -125,7 +126,8 @@ Use the `antithesis-documentation` skill to ground Antithesis-specific terminolo
 ## General Guidance
 
 - Prefer specific, checkable guarantees over vague goals like "test failover"
-- If the system claims a guarantee in docs, comments, or issues, try to make it a property
+- If the system's docs or comments claim a guarantee, make it a property to test — the property verifies the claim; don't state in the analysis that the guarantee holds
+- A bug report in an issue is a lead, not a fact. Confirm the reported defect is a real system defect before building anything on it (see `references/validating-claims.md`)
 - Record not just the invariant, but why the chosen Antithesis assertion type is the right semantic fit for that property
 - Use `Sometimes(cond)` for liveness or non-trivial semantic states, not for invariants that must hold on every evaluation and not as a substitute for `Reachable(...)`
 - Identify where surgical SUT-side assertions would give materially better search guidance than workload-only checks, especially for rare, dangerous, timing-sensitive, or externally invisible states
@@ -174,7 +176,8 @@ Review criteria:
 - `antithesis/scratchbook/property-relationships.md` exists and groups related properties into clusters with brief notes on suspected connections and dominance
 - Every property slug referenced in `property-relationships.md` corresponds to a property in the catalog
 - Properties focus on timing-sensitive, concurrency-sensitive, and partial-failure scenarios where Antithesis is strongest
-- Claimed guarantees from docs, comments, or issues are represented as properties
+- Claimed guarantees from docs or comments are represented as properties to test, and the analysis does not state any guarantee as an established fact
+- Any statement that a specific defect exists, taken from a bug report, cites primary evidence that the defect is real and rules out the reporter's environment or config — not just a link to the issue or a matching symptom
 - Property evaluation was performed: `antithesis/scratchbook/evaluation/synthesis.md` exists with categorized findings
 - Evaluation refinements have been applied to the catalog
 - Evaluation gaps have been filled via targeted discovery, and the resulting properties are in the catalog with evidence files

--- a/antithesis-research/references/property-catalog.md
+++ b/antithesis-research/references/property-catalog.md
@@ -24,7 +24,7 @@ Ask: "What exact condition would I check in code to verify this?" If you can't a
 
 ## Cross-Reference Closed Issues as Regression Targets
 
-A recently-fixed bug is a great Antithesis test because the fix may not cover all edge cases. For each closed bug in the target area:
+A recently-fixed bug is a great Antithesis test because the fix may not cover all edge cases. Confirm the real root cause and mechanism from the fix and the discussion before turning a closed issue into a property — the report's own description of the cause is a lead, not the confirmed mechanism, and some issues close as "not a bug" or user error and describe no system defect at all (see `references/validating-claims.md`). For each closed bug in the target area:
 
 - What was the root cause?
 - What timing or fault condition triggered it?

--- a/antithesis-research/references/property-discovery.md
+++ b/antithesis-research/references/property-discovery.md
@@ -139,13 +139,17 @@ Spawn one agent per focus. Each agent receives:
 - The path to `antithesis/scratchbook/existing-assertions.md` — read this before
   writing evidence files; for each property, note which assertions already exist
   vs. which are missing
-- The list of user-named external references with their `why` notes (from the scope question), so the agent can consult them as part of its analysis
+- The list of user-named external references with their `why` notes (from the scope question), so the agent can consult them as part of its analysis — treat each as a lead to validate, not a fact (see `references/validating-claims.md`)
 - These instructions:
 
 > Examine the codebase through the lens of your assigned attention focus. Produce
 > properties in the standard catalog format. For each property, include your
 > confidence (high/medium/low) and what evidence in the codebase supports it. If
 > this focus yields no relevant properties for this system, say so and explain why.
+> Before you build a property on a claim from an external source — an issue or a
+> doc — validate it per `references/validating-claims.md`: a reported bug is a
+> lead, not a fact, and must be confirmed a real system defect (not the reporter's
+> environment or config) before it becomes a property.
 
 **Wildcard agent:** The wildcard agent (Focus 11) runs in parallel with the others
 but receives different context. Instead of a "look for" list, it receives:
@@ -160,7 +164,7 @@ but receives different context. Instead of a "look for" list, it receives:
   the others search it.
 - The path to `antithesis/scratchbook/existing-assertions.md`
 - Access to the codebase
-- The list of user-named external references with their `why` notes (from the scope question), so the agent can consult them as part of its analysis
+- The list of user-named external references with their `why` notes (from the scope question), so the agent can consult them as part of its analysis — treat each as a lead to validate, not a fact (see `references/validating-claims.md`)
 
 ### Agent Output
 
@@ -232,11 +236,11 @@ After all agents complete, synthesize into a single property catalog:
 
 For each property that has open questions in its evidence file, spawn an agent to investigate. Run these in parallel — one agent per property with open questions.
 
-Each agent receives the path to the evidence file, codebase access, and the path to `antithesis/scratchbook/existing-assertions.md`.
+Each agent receives the path to the evidence file, codebase access, the path to `antithesis/scratchbook/existing-assertions.md`, and `references/validating-claims.md`.
 
 Each agent must:
 
-- Read the evidence file's explanation of why each question matters and investigate the code to answer it.
+- Read the evidence file's explanation of why each question matters and investigate the code to answer it. If a question asks whether a reported defect is real, confirm it per `references/validating-claims.md` — cite discriminating primary evidence, not the report's description.
 - Not fabricate answers. If a question can't be resolved from code, docs, or other available evidence, leave it open with partial findings noted. Tag `(partial: ...)` when there are partial findings; tag `(needs human input)` only after exhausting investigation against code and docs. Some questions legitimately need human input — that is a normal outcome, not a failure of the step.
 - Record an investigation log in the evidence file under an `### Investigation Log` heading (see `references/property-catalog.md` "Investigation Log") so the "attempted" check in `SKILL.md` self-review is auditable.
 - Update the evidence file: remove resolved questions, note partial findings, apply human-input tags. Correct any instrumentation suggestions against `existing-assertions.md` to reflect what already exists vs. what is missing.
@@ -254,8 +258,11 @@ focuses as a sequential checklist:
 2. Read `antithesis/scratchbook/existing-assertions.md` so you have the full
    picture of what's already instrumented before writing any evidence files.
 3. For each attention focus 1–10 in order, make an explicit pass through the
-   codebase with that lens. After each pass, add new properties to a running
-   catalog. If a focus yields nothing for this system, note why and move on.
+   codebase with that lens. Treat any claim from an external source (an issue or
+   doc) as a lead to validate, not a fact — confirm a reported bug is a real
+   defect per `references/validating-claims.md` before building a property on it.
+   After each pass, add new properties to a running catalog. If a focus yields
+   nothing for this system, note why and move on.
 4. Run the wildcard pass (Focus 11) last. Unlike the other passes, the wildcard is
    not a fresh examination — it deliberately builds on awareness of what the
    previous passes covered, looking for properties they missed.
@@ -279,7 +286,9 @@ focuses as a sequential checklist:
     code to answer them:
 
     - Read the evidence file's explanation of why each question matters and
-      trace the code to answer it.
+      trace the code to answer it. If a question asks whether a reported defect
+      is real, confirm it per `references/validating-claims.md` — cite
+      discriminating primary evidence, not the report's description.
     - Don't fabricate answers. Tag `(partial: ...)` when partial findings exist;
       tag `(needs human input)` only after exhausting investigation against code
       and docs.

--- a/antithesis-research/references/property-evaluation.md
+++ b/antithesis-research/references/property-evaluation.md
@@ -165,7 +165,7 @@ Before spawning agents, create a directory for evaluation evidence files at
 - The path to `antithesis/scratchbook/properties/` (evidence files directory)
 - One evaluation lens (its full description from above)
 - The path to write its evidence file
-- The list of user-named external references with their `why` notes
+- The list of user-named external references with their `why` notes — treat each as a lead to validate, not a fact (see `references/validating-claims.md`)
 - The `sut_path`, current `commit`, and today's date (so the agent can write provenance frontmatter on its evidence file)
 - These instructions:
 
@@ -255,9 +255,11 @@ After categorization:
    - The existing property catalog (to avoid duplicating existing properties)
    - The path to existing assertions
    - The property catalog format from `references/property-catalog.md`
-   - The list of user-named external references with their `why` notes
+   - The list of user-named external references with their `why` notes — treat each as a lead to validate, not a fact (see `references/validating-claims.md`)
 
-   Each agent returns properties in catalog format and writes evidence files.
+   Each agent returns properties in catalog format and writes evidence files. As
+   in property discovery, a reported bug must be confirmed a real system defect
+   per `references/validating-claims.md` before it becomes a property.
    Targeted discovery agents may carry forward unresolved questions in their
    new evidence files; they populate the Open Questions list per
    `references/property-catalog.md` ("Open Questions Conventions"). Synthesize
@@ -293,7 +295,8 @@ If your environment does not support sub-agents:
    builds on awareness of what the first 3 found, looking for what they missed.
 4. Categorize all findings as Gap, Bias, or Refinement.
 5. Address findings: apply refinements, fill gaps by running targeted discovery
-   passes, collect biases for the human.
+   passes (validate any external claim per `references/validating-claims.md`
+   before building a property on it), collect biases for the human.
 6. Write the synthesis to `antithesis/scratchbook/evaluation/synthesis.md`. Begin
    `synthesis.md` with provenance frontmatter per `references/scratchbook-setup.md`.
 

--- a/antithesis-research/references/sut-analysis.md
+++ b/antithesis-research/references/sut-analysis.md
@@ -16,10 +16,12 @@ Build a comprehensive understanding of the system — its architecture, componen
 Read the user-named external references gathered during scoping (see `SKILL.md` "Prerequisites and Scoping"). They are typically:
 
 - **Architecture docs:** Reveal the intended design and the guarantees the system claims to make.
-- **Open bugs (especially in target components):** These are known weaknesses. Antithesis may find deeper variants.
-- **Recently closed bugs (regression targets):** A fix that handles one case may miss related edge cases. These are high-value Antithesis targets.
+- **Open bugs (especially in target components):** Reported weaknesses. A bug report is one person's guess about a suspected defect and is often wrong about the cause — validate that each is a real system defect before building on it (see `references/validating-claims.md`). Once confirmed, Antithesis may find deeper variants.
+- **Recently closed bugs (regression targets):** A fix that handles one case may miss related edge cases. These are high-value Antithesis targets. Confirm the real mechanism from the fix and discussion first — some issues close as "not a bug."
 - **RFCs and design docs:** Reveal what developers know is hard. Sections labeled "future work" or "known limitations" are gold.
 - **Production incident reports:** Show what actually breaks in practice, not just what might break in theory.
+
+Everything here is a lead, not a fact: turn a source into an analysis statement or a property only after grounding it in primary evidence, and validate only what you build on. See `references/validating-claims.md`.
 
 ## Identify Claimed Properties
 
@@ -31,7 +33,7 @@ Every system makes guarantees. Extract them explicitly. Look for statements like
 - "Automatic failover completes within Y seconds"
 - "No data loss under semi-synchronous replication"
 
-These claimed properties become the foundation of the property catalog. If the system claims it, Antithesis should verify it.
+These claimed properties become properties for Antithesis to verify. A claimed guarantee is a claim to test, not a verified fact — don't state in the analysis that the guarantee holds; state that the system claims it and the property checks it. See `references/validating-claims.md`.
 
 ## Identify Attack Surfaces
 

--- a/antithesis-research/references/sut-discovery.md
+++ b/antithesis-research/references/sut-discovery.md
@@ -47,14 +47,17 @@ structures, channels, shared mutable globals, concurrent access to collections.
 Explicitly claimed invariants the system promises will never be violated. Look for:
 statements in docs, comments, or design docs like "acknowledged writes survive
 failover," "exactly one leader per partition," "no duplicate processing," "data is
-never corrupted." These become the foundation of safety properties.
+never corrupted." These become safety properties for Antithesis to test — a
+claimed guarantee is a claim to test, not a verified fact (see
+`references/validating-claims.md`).
 
 ### 5. Liveness Guarantees
 
 Progress properties the system promises will eventually hold. Look for: statements
 like "failover completes within X seconds," "queued work is eventually processed,"
 "clients eventually get a consistent view," "the system recovers automatically."
-These become the foundation of liveness properties.
+These become liveness properties for Antithesis to test — a claimed guarantee is a
+claim to test, not a verified fact (see `references/validating-claims.md`).
 
 ### 6. Bug History and Density
 
@@ -62,7 +65,10 @@ Map where bugs have clustered and where they haven't. Look for: components with
 many filed issues (hotspots), components with no bug history (suspiciously quiet —
 possibly undertested rather than correct), recently closed bugs (regression targets
 where the fix may not cover all edge cases), recurring bug patterns that suggest
-systemic issues.
+systemic issues. A filed issue is a reported bug, not a confirmed one — the
+reporter is often wrong about the cause. Before you build a property on a reported
+bug, confirm the defect is real from primary evidence, not the issue's description
+(see `references/validating-claims.md`).
 
 ### 7. Existing Test Strategy
 
@@ -153,7 +159,7 @@ Spawn one agent per focus. Each agent receives:
 - The general SUT analysis methodology from `references/sut-analysis.md`
 - One attention focus (its full description and "look for" guidance from above)
 - Access to the codebase, documentation, and issue tracker
-- The list of user-named external references with their `why` notes (from the scope question), so the agent can consult them as part of its analysis
+- The list of user-named external references with their `why` notes (from the scope question), so the agent can consult them as part of its analysis — treat each as a lead to validate, not a fact (see `references/validating-claims.md`)
 - These instructions:
 
 > Examine the system through the lens of your assigned attention focus, using the
@@ -172,7 +178,7 @@ but receives different context. Instead of a "look for" list, it receives:
   the detailed "Look for:" lists — the wildcard should know what territory is
   covered, not how the others search it.
 - Access to the codebase, documentation, and issue tracker
-- The list of user-named external references with their `why` notes (from the scope question), so the agent can consult them as part of its analysis
+- The list of user-named external references with their `why` notes (from the scope question), so the agent can consult them as part of its analysis — treat each as a lead to validate, not a fact (see `references/validating-claims.md`)
 
 ### Agent Output Format
 

--- a/antithesis-research/references/validating-claims.md
+++ b/antithesis-research/references/validating-claims.md
@@ -1,0 +1,81 @@
+# Validating External Claims
+
+External sources tell you things about the system. They are leads, not facts.
+A claim earns nothing by being written down somewhere — it earns a place in
+your analysis only when you have grounded it in evidence that *exhibits* the
+behavior (the code, logs, a repro), not merely a source that *asserts* it.
+
+You validate what you build on, not everything you read. A tracker holds
+thousands of claims; you will turn a handful into properties. Validation is the
+price of that promotion. A claim you are not building on, you leave inert. The
+moment a claim needs validation is the moment you would state it as something
+the system does, or turn it into a property.
+
+## Two Kinds of External Input
+
+**Claimed guarantees** — the system's own docs, design notes, and code comments
+asserting intended behavior ("acknowledged writes survive failover"). Turn
+these into properties and let Antithesis test them; that is what properties are
+for. The one discipline: do not write that the guarantee *holds*. Write that
+the system claims it and the property verifies it. A claimed guarantee is a
+claim to test, not a verified fact — docs drift and lie.
+
+**Bug reports** — an issue where someone reports a suspected defect. The weakest
+input there is: one person's guess about their own problem, and the reporter is
+frequently wrong about the cause. A bug report is nothing until you validate
+that the reported defect is a real defect in the system. Read the primary
+evidence — the attached logs, the repro, the mechanism in the code, the issue's
+resolution — and rule out the ordinary alternatives: the reporter's
+configuration, their environment, their misunderstanding. Only when the
+evidence shows a real system defect does the report become a weakness worth a
+property, grounded in the mechanism you found, not the reporter's description.
+Production incident reports and postmortems are the same kind of lead —
+usually stronger evidence than a single-reporter issue, but still validate that
+the cause was correctly attributed to the system before you build on it.
+
+## What Validation Requires
+
+Name the competing explanation before you look. For a reported bug it is almost
+always "this is the reporter's environment or config, not the system." Then read
+the evidence that tells the two apart, and record the specific detail that
+settles it. "The issue says split-brain" is not validation — it cites the claim.
+"The logs show hostname resolution failing before any quorum event" is
+validation — it discriminates. If you cannot quote the discriminating detail,
+you have not validated the claim, and it does not enter.
+
+Read past the headline to the part that carries the evidence. A claim in a
+title or first paragraph is a headline; the logs, repro, comments, and
+resolution are where the truth is — and they are the parts a hurried read
+skips. Weigh the source's standing, too: an open, uncommented, single-reporter
+issue is far weaker than a maintainer-confirmed one.
+
+If you investigate and cannot settle it, the claim still does not become a fact.
+Record it as an open question for a human under the file-level `Open Questions`
+heading (see `references/scratchbook-setup.md`) — an unvalidated claim has no
+property to attach to. Use the state tags from "Open Questions Conventions" in
+`references/property-catalog.md`. It does not become a property premise or a
+stated behavior.
+
+## Worked Example: Valkey Issue #1322
+
+The issue is titled "Sentinel split-brain after failover." Read only that far
+and you conclude Valkey's Sentinel has a split-brain defect — and every property
+built on top inherits a false premise.
+
+The issue is open, has no comments, no labels, one reporter. That alone makes it
+weak testimony, not an established behavior.
+
+The reporter attached six logs and a config. They tell a different story. The
+after-restart logs are flooded with `# Failed to resolve hostname
+'node-mz-0.example.com'`. The config uses hostname-based Sentinel
+(`resolve-hostnames yes`) and announces `node-0.example.com` — a different name
+scheme than the `node-mz-*` names the running nodes try to resolve. The failover
+loops: `+try-failover` then `-failover-abort-no-good-slave`, because Sentinel
+cannot resolve the replica it would promote.
+
+The competing explanation is the correct one: the nodes cannot resolve each
+other's hostnames after restart. That is a deployment/DNS misconfiguration.
+Sentinel is behaving correctly given names it cannot resolve. The report does
+not describe a Valkey defect, so it does not become a property. The
+discriminating evidence is those resolution-failure log lines, before any quorum
+event.


### PR DESCRIPTION
A research run trusted a GitHub issue's title as an established fact without reading the attached logs that would have refuted it — the reported "Sentinel split-brain" was the reporter's DNS misconfiguration, not a Valkey defect — and that false premise poisoned the rest of the analysis.

This teaches `antithesis-research` to treat claims from external sources as leads to validate, not facts to build on:

- **Claimed guarantees** (docs, comments) become properties for Antithesis to test — the analysis no longer states that a guarantee holds.
- **Bug reports** (issues) must be confirmed a real system defect — grounded in primary evidence, ruling out the reporter's environment or config — before an agent builds a property on them. Validate only what you promote, not every claim you read.

A new reference, `references/validating-claims.md`, holds the discipline and a worked example (Valkey issue #1322). The validation gate reaches every path that hands an agent the external-references list — SUT and property discovery (ensemble and single-agent), open-question investigation, and evaluation gap-fill — with a central rule in the scoping section as the backstop.

## Parked — need your call

1. **Positive worked example?** The only example is a *rejection* (a reported bug that wasn't real). A reviewer flagged that this risks over-rotating toward discarding useful leads, and suggested a second example where a bug validates into a real property (ideally a non-DNS failure class). I held off: adding it is an inferred gap rather than an observed failure, and the skeptical framing matches the intent that bug reports are validated by default. Add one, or leave as-is?

2. **Shipping a live third-party issue's point-in-time facts.** The worked example asserts current facts about valkey/valkey#1322 (open, no comments, one reporter) and concludes it's the reporter's misconfiguration. If Valkey later confirms a real defect, the example goes stale and reads as wrongly dismissive. Keep it as-is (its value is that it's real and verifiable), freeze it as "as of this writing," or fictionalize it?