### PR TITLE
Use Sometimes assertions to verify workload reach

### DIFF
--- a/antithesis-workload/SKILL.md
+++ b/antithesis-workload/SKILL.md
@@ -121,6 +121,7 @@ Use the `antithesis-documentation` skill to access these pages. Prefer `snouty d
 6. Read `references/interesting-values.md`
 7. Identify the property's value menu — boundary values plus configured-limit families. See `interesting-values.md` for the discovery process and worked examples
 8. Implement the chosen property: assertions, test commands, and supporting code
+9. Write Sometimes assertions as reach claims for the behaviors the workload is designed to drive (see `references/assertions.md`, "Sometimes Assertions as Workload Reach Claims"). Use `antithesis-launch` to run a test, then `antithesis-triage` to check which assertions fired — unfired ones are evidence the workload isn't reaching its targets and the starting point for iteration
 
 ### Post-triage iteration
 
@@ -167,5 +168,6 @@ Review criteria:
 - Helper files or directories are prefixed with `helper_` so Antithesis ignores them
 - Whatever provenance frontmatter was present in the catalog was displayed when presenting status, so the user could spot a mismatch with the system they're working on
 - `antithesis/scratchbook/property-catalog.md` is updated to reflect the implementation status of every property in scope, with provenance frontmatter reflecting the current codebase state (refresh `commit` and `updated`; preserve `sut_path` and `external_references` from the existing catalog). The frontmatter format is defined in the `antithesis-research` skill, `references/scratchbook-setup.md`.
+- Sometimes assertions exist as reach claims for the behaviors the workload is designed to drive, and unfired reach claims from a test run have been used as the iteration signal (see `references/assertions.md`, "Sometimes Assertions as Workload Reach Claims")
 - Assertions are in workload code or surgical SUT locations — not scattered across production paths
 - Use `snouty validate` on `antithesis/config` to ensure that the compose setup can reach setup complete and any configured test-templates work. Make sure to build the latest images before running validate.

--- a/antithesis-workload/references/assertions.md
+++ b/antithesis-workload/references/assertions.md
@@ -93,6 +93,16 @@ Don't write `Always(observed_delta == 100, ...)` for the same property — that 
 - Good: `Unreachable("redirect emitted with missing leader address")`
 - Bad: reusing `"client eventually completed useful operation"` across several unrelated callsites
 
+## Sometimes Assertions as Workload Reach Claims
+
+Sometimes assertions have a second use beyond liveness and semantic-state properties: empirical proof that the workload reaches the states it is designed to exercise.
+
+For each behavior the workload is designed to drive the system toward, write one or more `Sometimes(cond, ...)` assertions that fire when that behavior actually occurs. Run a test. After the run, check which of these assertions fired and which did not. A Sometimes assertion that never fires is concrete evidence that the workload is not reaching where you believe it should — and the set of unfired assertions is a prioritized list of what to fix in the workload.
+
+This is workload development, not evaluation. The assertions are claims about what the workload should reach; the test results are the evidence. The unfired assertions become the iteration signal — see `iteration.md` for how to act on them.
+
+The correspondence between behaviors and assertions is not necessarily one-to-one. A single behavior might warrant several Sometimes assertions at different points in the path, or one assertion might cover the essential signal for a behavior. Use as many as it takes to know whether the workload is reaching a behavior, and no more.
+
 ## Assertion Placement
 
 - **Workload-level assertions:** Use for request/response invariants and client-visible guarantees.

--- a/antithesis-workload/references/iteration.md
+++ b/antithesis-workload/references/iteration.md
@@ -12,8 +12,9 @@ After running `antithesis-triage` on a completed test run and reviewing the resu
 
 1. Review which properties passed, failed, or were unfound.
 2. For failed properties, decide whether the problem is a SUT bug, a flawed assertion, or a workload gap.
-3. For unfound properties, add or adjust commands until the relevant code paths become reachable. When extra guidance is needed, prefer targeted `Reachable(...)`, `Unreachable(...)`, or non-trivial `Sometimes(cond, ...)` assertions in the SUT over generic workload-side canaries.
-4. For newly discovered behaviors, add new properties and assertions and record them in the Antithesis scratchbook.
+3. For unfound properties, check whether Sometimes reach claims (see `assertions.md`, "Sometimes Assertions as Workload Reach Claims") cover the relevant behaviors. Unfired Sometimes assertions are the sharpest signal — each one names a behavior the workload was designed to drive but did not. Use them as the prioritized list of what to fix: add or adjust commands until the unfired assertions start firing. When no reach claims exist for the unfound property, add them as part of the fix so the next run has the signal.
+4. When extra guidance is needed beyond workload changes, prefer targeted `Reachable(...)`, `Unreachable(...)`, or non-trivial `Sometimes(cond, ...)` assertions in the SUT over generic workload-side canaries.
+5. For newly discovered behaviors, add new properties and assertions and record them in the Antithesis scratchbook.
 
 ## Common Improvements
 


### PR DESCRIPTION
The workload skill teaches Sometimes assertions for liveness and
semantic states, and teaches iteration after triage. What was missing:
the deliberate practice of writing Sometimes assertions as claims about
what the workload should reach, then using unfired assertions as
evidence that the workload's driving needs improvement.

Three files change:

- `references/assertions.md` — new section "Sometimes Assertions as
  Workload Reach Claims" framing the practice: write one or more
  Sometimes assertions per behavior the workload targets, run a test,
  use unfired assertions as the iteration priority list.
- `references/iteration.md` — step 3 now checks unfired reach claims
  first when addressing unfound properties, and tells the agent to add
  reach claims when none exist.
- `SKILL.md` — new step 9 in "Implement next property" for writing
  reach claims and verifying them via launch/triage. New self-review
  criterion.
