### PR TITLE
feat: add antithesis-feature-workload skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Enable AI agents to set up Antithesis, bootstrap your first Antithesis test, lau
 
 `antithesis-launch` enables agents to build the harness, run `snouty validate`, and submit `snouty launch` with sensible metadata once the harness is ready.
 
+`antithesis-feature-workload` is a focused entry point for testing a specific feature with Antithesis. Bring a feature — done or still in development — and this skill analyzes it, discovers testable properties, and builds a self-driving workload that runs locally and in Antithesis. For in-development features, the workload includes TDD-style stubs that go green as code lands. Unlike the broad research → setup → workload pipeline, this skill goes straight from feature analysis to a targeted workload.
+
 `antithesis-skills-feedback` helps you file bug reports against these skills by opening a pre-filled GitHub issue.
 
 > [!NOTE]
@@ -120,6 +122,18 @@ Here's an example:
 
 This skill implements Antithesis workloads and places all the test commands and supporting files under `antithesis/test/`, adds assertions to carefully chosen locations in the SUT.
 
+### antithesis-feature-workload
+
+```
+/antithesis-feature-workload I'm building a new batch processing feature in src/batch/. Help me design an Antithesis workload to test it.
+```
+
+```
+/antithesis-feature-workload We just shipped the new replication feature. Build a workload that exercises it and checks its invariants.
+```
+
+This skill analyzes the feature, discovers testable properties, and builds a self-driving workload with dual-mode assertions (SDK in Antithesis, local checks outside). Outputs go to `antithesis/feature-workloads/<feature-slug>/`.
+
 ### antithesis-launch
 
 ```
@@ -156,6 +170,7 @@ Here are the tools each skill may invoke, so you can pre-approve them if you pre
 | `antithesis-setup`         | `docker compose`/`docker-compose`, `docker`/`podman`, `snouty` |
 | `antithesis-setup-k8s`     | `docker`/`podman`, `snouty`                                    |
 | `antithesis-workload`      | `snouty`                                                       |
+| `antithesis-feature-workload` | `docker compose`/`docker-compose`, `docker`/`podman`, `snouty` |
 | `antithesis-launch`        | `docker compose`/`docker-compose`, `docker`/`podman`, `snouty` |
 | `antithesis-triage`        | `snouty`, `jq`                                                 |
 | `antithesis-debug`         | `agent-browser`, `jq`                                          |
@@ -186,6 +201,7 @@ The installer presents an interactive menu. Choose the following options:
    - `antithesis-query-logs`
    - `antithesis-agent-browser`
    - `antithesis-launch`
+   - `antithesis-feature-workload`
    - `antithesis-skills-feedback`
 2. **Install scope** — choose **global**, not project.
 3. **Install method** — choose **symlink**.

--- a/antithesis-feature-workload/SKILL.md
+++ b/antithesis-feature-workload/SKILL.md
@@ -188,7 +188,8 @@ For when the feature evolves and the workload needs to keep up:
 2. Check which properties still hold, which are new, which are obsolete
 3. Update workload, assertions, and reach claims — TDD-style stubs for new
    unbuilt parts, remove stubs for parts that are now built and passing
-4. Re-validate locally
+4. Re-validate locally — check reach claims, iterate as in the main
+   workflow's step 13 if results show gaps
 
 ## General Guidance
 

--- a/antithesis-feature-workload/SKILL.md
+++ b/antithesis-feature-workload/SKILL.md
@@ -1,0 +1,292 @@
+---
+name: antithesis-feature-workload
+description: >-
+  Design and build an Antithesis workload for a specific feature: analyze the
+  feature, discover its testable properties, build a self-driving workload
+  that runs locally and in Antithesis, and iterate until the feature's
+  behaviors are exercised and its invariants are checked.
+metadata:
+  version: 0.0.0
+  model_guidance:
+    - model: all
+      level: required
+      instructions: >
+        This skill teaches you how to build an Antithesis workload scoped to
+        a specific feature. Start from a feature — done or in development —
+        understand what it does and what could go wrong, discover testable
+        properties, and build a self-driving workload that exercises the
+        feature's behaviors and checks its invariants. The workload does NOT
+        use Test Composer — it is a self-driving program that runs identically
+        locally and in Antithesis.
+---
+
+# Build a feature workload for Antithesis
+
+## Purpose and Goal
+
+Start from a specific feature and produce a workload that tests it.
+Success means:
+
+- The feature is understood well enough to identify its testable properties
+- Properties are concrete and specific — invariants, reachable behaviors,
+  failure modes — not vague goals
+- A self-driving workload exists that exercises the feature's behaviors
+- Reach claims fire, proving the workload reaches the feature's important
+  states
+- Feature invariants are checked by assertions that use the correct SDK types
+- Optionally: the workload has run in Antithesis and findings have been
+  verified
+
+This skill is a parallel entry point into the Antithesis workflow. Where the
+standard pipeline goes research → setup → workload (broad coverage), this
+skill goes feature analysis → targeted workload → iterate (feature focus).
+
+## Entry Points
+
+This skill handles two starting points:
+
+- **Feature is done**: Source code is available. Full analysis, full workload,
+  all assertions expected to pass.
+- **Feature is in development**: Some code may exist, or just a spec or idea.
+  The workload includes TDD-style stubs — assertions that fail until the
+  feature catches up. As code lands, assertions go green. The "Update workload
+  for feature changes" workflow handles evolution.
+
+Both entry points go through the same workflow. What varies is how many
+assertions pass on the first run.
+
+## Prerequisites
+
+- A feature to test — source code, a spec, a description, or a combination
+- Access to the SUT source code
+- Docker Compose v2 and a container engine (Docker or Podman) for local runs
+- `snouty` CLI installed when moving to Antithesis runs (not needed for
+  local-only work)
+
+## Relationship to Other Skills
+
+- **antithesis-research**: Feature-workload performs *feature-scoped* analysis
+  — the same codebase exploration techniques narrowed to "what could go wrong
+  with this feature" rather than "what properties does this entire system
+  have." If full research artifacts already exist in the scratchbook, use them
+  as context but don't require them.
+- **antithesis-workload**: Feature-workload builds self-driving workloads, not
+  Test Composer commands. Assertion patterns, value menus, fault-tolerant
+  design, and reach claims apply to both — this skill carries its own
+  reference material adapted for feature-scoped work.
+- **antithesis-setup**: Feature-workload does not assume Antithesis
+  infrastructure is or isn't set up. When the user wants to move to Antithesis
+  and infrastructure is needed, delegate to `antithesis-setup`.
+- **antithesis-launch**: Use to submit Antithesis runs. Do not run
+  `snouty launch` directly.
+- **antithesis-triage**: Use after each Antithesis run with a focused lens:
+  "are the feature's properties being exercised? Any failures?" rather than a
+  broad property portfolio review.
+- **antithesis-debug**: Use when triage shows a property failure that needs
+  deeper investigation — inspect container state at the failure moment,
+  time-travel to understand the sequence.
+
+## Definitions
+
+- **SUT:** System under test.
+- **Feature property:** A concrete, testable claim about what the feature
+  should do, what invariants it should maintain, or what behaviors should be
+  reachable.
+- **Reach claim:** A `Sometimes` assertion that verifies the workload actually
+  exercises a feature behavior. Unfired reach claims mean the workload isn't
+  reaching the right states.
+- **Self-driving workload:** A single program that drives the SUT, checks
+  invariants, and runs without external orchestration. No Test Composer.
+- **Dual-mode:** The workload uses SDK assertions when `ANTITHESIS_OUTPUT_DIR`
+  is set (Antithesis) and equivalent local checks when it is not (local).
+
+## Documentation Grounding
+
+Use the `antithesis-documentation` skill to access Antithesis docs.
+
+- SDK reference: `https://antithesis.com/docs/reference/sdk.md`
+- Properties and assertions: `https://antithesis.com/docs/concepts/properties_assertions/assertions.md`
+- Fault injection: `https://antithesis.com/docs/product/fault_injection.md`
+- Docker Compose setup: `https://antithesis.com/docs/getting_started/setup_guide/docker_compose.md`
+
+## Reference Files
+
+| Reference                             | When to read                                          |
+| ------------------------------------- | ----------------------------------------------------- |
+| `references/feature-analysis.md`      | First — system orientation, understanding the feature, discovering properties |
+| `references/self-driving-workload.md` | Building the workload                                 |
+| `references/assertions.md`            | Writing assertions for feature properties and reach claims |
+| `references/interesting-values.md`    | Choosing values that exercise the feature's boundaries |
+| `references/faults.md`               | Assessing whether fault injection matters for this feature |
+| `references/iteration.md`            | When reach claims aren't firing or properties aren't exercised |
+| `references/verification.md`         | Verifying a finding is real                            |
+
+## Recommended Workflows
+
+### Design and build a feature workload
+
+1. Read `references/feature-analysis.md`
+2. Orient to the system: if existing research artifacts exist in
+   `antithesis/scratchbook/`, read them; otherwise build a lightweight
+   orientation scoped to the feature's neighborhood — architecture, data flow,
+   concurrency model
+3. Understand the feature — from code, spec, conversation, or combination.
+   For features in development, identify what's built vs. planned
+4. Discover feature properties — invariants, reachable behaviors, failure
+   modes. For features in development, properties for unbuilt parts become
+   TDD-style stubs
+5. Read `references/faults.md` to assess which fault types matter for this
+   feature
+6. Record findings in
+   `antithesis/feature-workloads/<feature-slug>/analysis.md`
+7. Read `references/self-driving-workload.md`
+8. Read `references/assertions.md`
+9. Read `references/interesting-values.md`
+10. Build value menus from boundary values and configured-limit families on
+    the feature's code paths
+11. Design and build the workload: self-driving program with dual-mode
+    assertions, fault tolerance, operation tracking, and reach claims for the
+    feature's key behaviors
+12. Build docker-compose for local runs (or use existing setup)
+13. Run locally. Read `references/iteration.md` when reach claims aren't
+    firing or properties aren't being exercised. Iterate: check reach claims
+    first, then adjust workload, assertions, SUT config, or properties as the
+    evidence directs
+    - Reach claims not firing → adjust workload or revisit feature
+      understanding
+    - Properties not being exercised → adjust operations, values, or
+      assertions
+    - Feature understanding seems wrong → loop back to step 3
+14. If moving to Antithesis:
+    a. Check existing setup; use `antithesis-setup` if infrastructure is needed
+    b. Use `antithesis-launch` for runs
+    c. Use `antithesis-triage` for analysis (framed: "are the feature's
+       properties being exercised? Any failures?")
+    d. Based on triage results: if a property failed, go to step 15; if reach
+       claims aren't firing, go to "Iterate after a run"; if the mechanism is
+       unclear, use `antithesis-debug` for deeper inspection
+15. When a property fails, read `references/verification.md`. Classify the
+    finding. Any real bug found while testing a feature is valuable.
+16. Document findings in
+    `antithesis/feature-workloads/<feature-slug>/analysis.md`
+
+### Iterate after a run
+
+1. Read `references/iteration.md`
+2. Read `references/assertions.md` if assertions need to change
+3. Check reach claims — are feature behaviors being reached?
+4. Choose iteration moves based on what you observe: workload adjustments,
+   assertion adjustments, SUT configuration changes, or property revision
+5. Update `antithesis/feature-workloads/<feature-slug>/analysis.md` with what
+   changed, what was observed, and what to try next
+
+### Update workload for feature changes
+
+For when the feature evolves and the workload needs to keep up:
+
+1. Re-read the feature (what changed in the code or spec)
+2. Check which properties still hold, which are new, which are obsolete
+3. Update workload, assertions, and reach claims — TDD-style stubs for new
+   unbuilt parts, remove stubs for parts that are now built and passing
+4. Re-validate locally
+
+## General Guidance
+
+- **One feature at a time.** Don't try to build workloads for multiple
+  features simultaneously. Each feature gets its own analysis, workload, and
+  iteration cycle.
+- **Properties drive the workload.** Every operation, assertion, and value
+  choice should connect to a discovered feature property. If work doesn't
+  relate to a property, either discover a new property or stop.
+- **Reach claims are the compass.** Unfired reach claims tell you the workload
+  isn't exercising the feature's key behaviors. Check them first on every
+  iteration — before adjusting anything else, make sure the workload is
+  reaching the right states.
+- **Local is the default starting point.** Start locally unless the feature's
+  properties explicitly require Antithesis capabilities (fault injection,
+  scheduling control). Local iteration is faster and gives tighter feedback
+  loops.
+- **Verify before declaring victory.** A property failure is a candidate, not
+  a confirmed bug. Read the counterexample. Understand the sequence. Confirm
+  the mechanism. Harness bugs, assertion bugs, and workload bugs all produce
+  property failures too.
+- **Record everything.** The feature-workloads directory is the trail from
+  "we have a feature" to "we have a working workload." Future readers need to
+  understand what properties were discovered, what was tested, and what was
+  found.
+- **Design workloads to be fault-tolerant.** Under Antithesis fault injection,
+  transient errors are expected. The workload must make progress through
+  failures — retry with backoff, reconnect on disconnect, and track what was
+  attempted vs what was acknowledged.
+- **Keep Antithesis-only code out of production paths.** If you must touch
+  shared code for assertions, make the change surgical. SDK assertions no-op
+  outside Antithesis, so the production cost is negligible.
+- **Write workload code in the project's language** so it can reuse the
+  project's clients, helpers, and libraries.
+- **The workload grows with the feature.** For in-development features, build
+  the full workload with TDD-style stubs for unbuilt parts. Assertions go
+  green as code lands. Don't wait for completion to start testing.
+
+## Output
+
+- `antithesis/feature-workloads/<feature-slug>/analysis.md` — feature
+  properties, codebase findings, fault assessment, iteration history
+- Workload code (self-driving program with dual-mode assertions)
+- `docker-compose.yml` for local runs (unless existing setup suffices)
+- Assertions targeting feature invariants plus reach claims for feature
+  behaviors
+
+## Self-Review
+
+Before declaring this skill complete, review your work against the criteria
+below. If your agent supports sub-agents, create a fresh-context reviewer.
+
+Review criteria:
+
+- System orientation was performed — enough understanding of the architecture,
+  data flow, and concurrency model to navigate the feature's neighborhood (or
+  existing research artifacts were used)
+- Feature properties are documented in `analysis.md` and connect to specific
+  code paths with evidence from the codebase (or to planned behavior for
+  in-development features)
+- Each property is concrete and testable — not a vague goal like "test the
+  feature" but a specific invariant, reachable behavior, or failure mode
+- The workload exercises the feature's key behaviors (verified by reach claims
+  that actually fire — or, for in-development features, reach claims for built
+  parts fire while stubs for unbuilt parts are clearly marked)
+- Assertions use the correct SDK type for their semantics (`Always` /
+  `AlwaysOrUnreachable` for invariants, `Sometimes` for reach claims,
+  `Reachable` for path reachability) — see `references/assertions.md`
+- `Sometimes(true, ...)` assertions should be rewritten as `Reachable(...)`
+- The workload is a self-driving program with a single entrypoint, not Test
+  Composer commands
+- The workload is fault-tolerant — retries transient errors, makes progress
+  through failures, doesn't bail on the first error
+- The workload tracks attempted vs acknowledged operations so assertions can
+  check bounds, not exact values
+- The workload is dual-mode — SDK assertions when `ANTITHESIS_OUTPUT_DIR` is
+  set, local checks otherwise
+- Reach claims assert the precondition, not the violation — they fire when the
+  system is correct
+- No reach claim is the negation of an `Always` or `AlwaysOrUnreachable` at
+  the same site
+- Value choices use boundary values and configured-limit families from the
+  feature's code paths, not arbitrary ranges — see
+  `references/interesting-values.md`
+- Assertion property names are inline constant string literals, unique across
+  the project — never constructed at runtime
+- Randomness in the workload goes through the SDK's random module for
+  deterministic replay (standard library random for local mode)
+- Randomness shape varies across runs (swarm testing) — probabilities and
+  action weights are drawn at the start of each run, not hardcoded
+- Workload-only instrumentation was not used where surgical SUT-side
+  assertions would provide materially better search guidance for rare,
+  dangerous, or timing-sensitive internal states
+- Assertions are in workload code or surgical SUT locations — not scattered
+  across production paths
+- If moving to Antithesis: the `antithesis-setup` skill was used for
+  infrastructure, not ad-hoc setup
+- If fault types are relevant to the feature's properties: those faults are
+  confirmed as enabled for the tenant — see `references/faults.md`
+- The feature-workloads directory records what was analyzed, what properties
+  were discovered, what was tested, and what was found at each iteration

--- a/antithesis-feature-workload/references/assertions.md
+++ b/antithesis-feature-workload/references/assertions.md
@@ -1,0 +1,194 @@
+# Assertions
+
+## Goal
+
+Write Antithesis SDK assertions that check the feature's properties and
+verify that the workload reaches the feature's important states.
+
+A feature workload typically has three kinds of assertions:
+
+1. **Feature invariants**: `Always` or `AlwaysOrUnreachable` assertions that
+   check the feature's correctness properties. These detect real bugs — when
+   an invariant fails, the feature is broken.
+2. **Behavior reach claims**: `Sometimes` assertions that verify the workload
+   exercises the feature's key behaviors — the states and transitions that
+   matter for the feature under test.
+3. **Operational reach claims**: `Sometimes` assertions that verify the
+   workload is performing its intended operations at all.
+
+## Match the Assertion to the Property Type
+
+- **`Always`**: Use for feature invariants — conditions that must hold every
+  time the check runs. When this assertion fails, the feature has a bug.
+  Example: "acknowledged writes are never lost after failover."
+- **`AlwaysOrUnreachable`**: Use for invariants on optional or rare paths
+  where "never executed" is acceptable but any execution must satisfy the
+  invariant. Example: "if the batch-flush fast path runs, it never drops
+  committed entries."
+- **`Reachable`**: Use when the fact that execution reached a specific outcome
+  is the signal. Example: "concurrent update completed successfully,"
+  "retry loop drained work."
+- **`Unreachable`**: Use for forbidden paths. Example: "corruption recovery
+  path entered," "double-spend accepted."
+- **`Sometimes(cond)`**: Use for reach claims — liveness or semantic states
+  that should become true at least once. The condition must itself be
+  meaningful. Example: "leader election completes," "workload successfully
+  processes a batch."
+
+## Rich Assertions
+
+Some SDKs expose richer assertion helpers. Check whether the SDK you are
+using offers them. Use a rich form when it cleanly matches the property; use
+plain assertions when they're clearer.
+
+### Numeric Rich Assertions
+
+Use when the property is a numeric comparison:
+
+- `AlwaysGreaterThan(left, right)` / `AlwaysGreaterThanOrEqualTo(left, right)`
+- `AlwaysLessThan(left, right)` / `AlwaysLessThanOrEqualTo(left, right)`
+- `SometimesGreaterThan(left, right)` / `SometimesGreaterThanOrEqualTo(left, right)`
+- `SometimesLessThan(left, right)` / `SometimesLessThanOrEqualTo(left, right)`
+
+These fit thresholds, bounds, ordering, counts, sizes, queue depths, version
+numbers, timestamps, latency, and duration checks. The SDK adds operands to
+assertion details automatically.
+
+### Boolean Rich Assertions
+
+Use when the property is about a set of named booleans:
+
+- `AlwaysSome(named_bools)`: every evaluation must have at least one true.
+- `SometimesAll(named_bools)`: at least one evaluation must have all true.
+
+These fit replication checks ("data in at least one replica"), quorum checks
+("at least one backend healthy"), combined-state checks ("all replicas alive
+simultaneously").
+
+## Assert Bounds, Not Exact Values
+
+Under fault injection, the workload can't observe everything that happened.
+Construct bounds from attempted and acknowledged operations, and assert that
+observed state falls within those bounds.
+
+Use two assertions for a bound, not one, so triage shows which side failed:
+
+- `AlwaysGreaterThanOrEqualTo(observed, acknowledged, "reflects all acked")`
+- `AlwaysLessThanOrEqualTo(observed, attempted, "reflects no more than attempted")`
+
+Don't write `Always(observed == attempted, ...)` — that fires legitimately
+whenever the environment dropped requests, drowning real bugs in false
+positives.
+
+## Reach Claims
+
+Reach claims are `Sometimes` assertions that prove the workload reaches the
+states it is designed to exercise. For feature testing, the most important
+reach claims are for the feature's **key behaviors** — the states and
+transitions the workload must drive the system through.
+
+After each run (local or Antithesis), check which reach claims fired and which
+did not. An unfired reach claim is concrete evidence that the workload is not
+exercising what it needs to — and the set of unfired claims is the prioritized
+list of what to fix. This is the primary iteration signal.
+
+### Sometimes Assertions as Workload Reach Claims
+
+Write `Sometimes` assertions for the behaviors the workload is designed to
+drive. Assert the precondition — the state where the interesting behavior
+*can* occur — not the violation itself. Use `antithesis-launch` to run a
+test, then `antithesis-triage` to check which assertions fired. Unfired ones
+are evidence the workload isn't reaching its targets and the starting point
+for iteration.
+
+### A Reach Claim Asserts the Precondition, Never the Violation
+
+A reach claim says the workload reaches the state where interesting behavior
+*can* occur. It does not say the bug occurs.
+
+Do not write `Sometimes(X)` next to `Always(!X)`. The `Sometimes` fires only
+when the `Always` fails. On a correct system, the `Sometimes` never fires,
+and Antithesis reports it as a failure.
+
+Test each reach claim: does it still fire when the system is correct? If not,
+assert the precondition that makes the violation possible.
+
+- Bad: `Always(!(stale_read && served_to_client))` with
+  `Sometimes(stale_read && served_to_client)`
+- Good: `Always(!(stale_read && served_to_client))` with
+  `Sometimes(stale_read)` and `Sometimes(served_to_client)`
+
+Assert each part of the precondition separately. Both good claims fire when
+the system is correct. Together they show the workload reaches the window
+where a stale read could be served.
+
+## Assertion Placement
+
+- **Workload-level assertions**: Request/response invariants and client-visible
+  guarantees. This is where most feature workload assertions live — they
+  check what the feature does from the outside.
+- **SUT-side assertions**: Internal invariants, rare internal states, branch
+  guidance, forbidden paths. Add these when the feature involves internal
+  state the workload cannot observe directly.
+- Keep SUT-side assertions surgical and minimize churn, but add them when they
+  materially improve the ability to detect violations or guide the search
+  toward the feature's interesting states.
+
+## When to Instrument the SUT Directly
+
+Add SUT-side assertions when a state relevant to the feature is dangerous,
+timing-sensitive, hard to observe externally, or useful as a branch or replay
+anchor.
+
+Good candidates:
+
+- Internal state transitions on the feature's critical paths
+- Locking/unlocking or ownership changes
+- Queue admission, wait, timeout, drain, retry outcomes
+- Leader election, handoff, or leadership-loss internals
+- Cache invalidation or replication lag events
+- Recovery or rollback logic
+
+Prefer outcome markers over path-entry markers. If a later marker tells you
+the branch result, the earlier generic marker is usually noise.
+
+## Use Deterministic Randomness
+
+All randomness in the workload must go through the Antithesis SDK's random
+module for deterministic replay. When running locally (no SDK), use the
+standard library's random module instead.
+
+## Anti-Rules
+
+- Do not use `Sometimes(true, ...)`. Use `Reachable(...)` instead.
+- Do not use `Sometimes(cond, ...)` when you only care about path reachability.
+  Use `Reachable(...)`.
+- Do not reuse one assertion message across multiple unrelated callsites.
+- Do not construct assertion property names at runtime or pass them through
+  variables.
+- Do not stack broad early `Reachable(...)` markers on a straight-line flow
+  when a later, more specific outcome marker already proves the path was
+  exercised.
+- Do not assert exact equality on values affected by transient errors. Use
+  bounded assertions.
+- Do not write `Sometimes(X, ...)` next to `Always(!X, ...)`.
+
+## Naming
+
+Give assertions clear, descriptive, unique names. These appear in triage
+reports and must immediately identify one specific callsite or condition.
+
+Every assertion property name must be:
+
+- **Inline**: A string literal at the callsite, not a variable or function
+  result.
+- **Constant**: Never constructed at runtime. No concatenation, format strings,
+  or interpolation.
+- **Unique**: No two callsites anywhere in the project may share a name.
+
+These are hard requirements. Antithesis statically analyzes all software during
+instrumentation to pre-catalog every assertion. Pre-cataloging is what makes
+reachability and unreachability meaningful: to report that a `Reachable` was
+never hit, Antithesis must know it exists. A name built at runtime is invisible
+to static analysis, a duplicated name collapses distinct callsites into one
+catalog entry.

--- a/antithesis-feature-workload/references/faults.md
+++ b/antithesis-feature-workload/references/faults.md
@@ -1,0 +1,139 @@
+# Faults
+
+## Goal
+
+Understand what faults Antithesis can inject so you can assess which fault
+types matter for the feature's properties and whether local testing is
+sufficient or Antithesis is needed.
+
+## Fault Categories
+
+Antithesis injects faults at the **container level** — everything in a
+container shares the same fate. Placing two services in one container means
+they will never experience faults in their communication with each other.
+
+### Network Faults
+
+Network faults disrupt packet delivery between containers. Incoming and
+outgoing packets are treated independently, so all network faults are
+potentially **asymmetric** (one direction disrupted while the other works).
+
+**Baseline latency**: Always-on simulated delay and low baseline packet drop.
+Not a fault event — this is the normal environment.
+
+**Congestion**: Elevated packet loss and latency. Packets are often reordered.
+
+**Basic network faults**: Two containers temporarily lose their connection.
+Can slow, drop, or suspend packet delivery per stream.
+
+**Partitions**: Containers split into groups. Communication within a group is
+normal; between groups is disrupted. Configurable by frequency, symmetry,
+group count, and duration.
+
+**Bad nodes**: One or more containers lose the ability to communicate.
+Inbound, outbound, or both.
+
+For partitions and bad-node faults, disruption can be: all packets dropped,
+packets held then delivered at once, or packets delivered with added latency
+and probabilistic drops.
+
+### Node Faults
+
+**Node hang**: Container becomes totally unresponsive temporarily, then
+resumes.
+
+**Node throttling**: Container's CPU is limited, making it slow and less
+responsive — surfaces bugs that load would find.
+
+**Node termination**: Container is gracefully shut down or crash-killed, then
+restored after a random delay. Restarted containers may get new IPs and lose
+non-durable state. **Disabled by default** — must be explicitly enabled for
+the tenant.
+
+### Clock Faults
+
+**Clock jitter**: System clock jumps forward or backward (daylight savings,
+leap seconds, timezone changes). Affects all containers equally. Low-level
+intrinsics like `__rdtsc()` are unaffected.
+
+### Other Faults
+
+**Thread pausing**: Individual threads are paused briefly, causing unexpected
+interleavings. Requires instrumentation.
+
+**CPU modulation**: Simulated processor clock speed changes, altering
+concurrent thread execution order. Can trigger some of the same bugs as
+thread pausing without instrumentation.
+
+**Custom faults**: User-defined scripts invoked by the fault injector at
+random intervals. Common uses: toggling admin config, triggering
+compaction/GC, forking background processes.
+
+## Fault Availability
+
+Not all fault types are enabled by default. The set depends on tenant
+configuration and the webhook used to launch runs. Node termination and clock
+faults are commonly disabled in default configurations.
+
+If a feature property depends on a specific fault type (e.g., testing crash
+recovery requires node termination), confirm with the user that the fault is
+enabled for their tenant. A workload that depends on a disabled fault will not
+exercise the property.
+
+## Mapping Faults to the Feature
+
+When assessing which faults matter for a feature, consider which faults could
+reveal problems in the feature's behavior:
+
+- **Data replication features**: Network partitions and bad-node faults test
+  whether writes propagate correctly when nodes are isolated. Congestion tests
+  whether replication handles reordered or delayed messages.
+- **Leader election / coordination features**: Network partitions and bad-node
+  faults create the communication breakdowns that split-brain requires. Node
+  termination tests leadership handoff.
+- **Crash recovery features**: Node termination tests whether the feature
+  recovers state correctly after a restart. Must be explicitly enabled.
+- **Caching features**: Network partitions and congestion delay updates,
+  creating stale-data windows. Clock jitter tests TTL and expiration logic.
+- **Timeout / retry features**: Baseline latency, congestion, and node
+  throttling make operations take longer than expected. Tests whether timeout
+  and retry logic handles edge cases.
+- **Scheduling / time-dependent features**: Clock jitter tests assumptions
+  about monotonic time, expiration, and ordering.
+- **Configuration management features**: Custom faults can toggle config
+  during operation, testing hot-reload behavior.
+- **Concurrent access features**: Thread pausing, CPU modulation, and network
+  delays alter timing and can widen race windows in shared-state access.
+
+## Quiet Periods
+
+Antithesis provides `ANTITHESIS_STOP_FAULTS` to temporarily pause all fault
+injection. This gives the system a recovery window. See
+`references/self-driving-workload.md` for how to use quiet periods in
+self-driving workloads.
+
+Quiet periods are relevant to feature testing when:
+
+- The feature involves recovery behavior — verify it actually recovers after
+  faults stop
+- You need to check a liveness property (system eventually converges)
+- The feature's properties require observing behavior during a
+  fault-then-recovery sequence
+
+## Relevance to Testing Strategy
+
+When deciding whether a feature needs Antithesis or can be tested locally:
+
+- Features whose properties require **network partitions**, **node
+  termination**, **clock jitter**, or **thread pausing** almost always need
+  Antithesis — local testing can't reliably produce these conditions.
+- Features whose properties require only **concurrent operations** or
+  **specific timing** may be testable locally under load — Antithesis helps
+  but isn't strictly required.
+- Features whose properties require **specific values** or **specific
+  operation sequences** are usually testable locally if you can construct the
+  right workload.
+
+Start locally regardless. Even features that ultimately need Antithesis
+benefit from local validation to confirm the workload works, reach claims
+fire, and assertions are correct before paying for Antithesis runs.

--- a/antithesis-feature-workload/references/feature-analysis.md
+++ b/antithesis-feature-workload/references/feature-analysis.md
@@ -1,0 +1,333 @@
+# Feature Analysis
+
+## Goal
+
+Understand a specific feature well enough to identify its testable properties
+and build a workload that exercises them. This is not a system survey — it is
+focused exploration scoped to the code paths, state, concurrency, and failure
+modes relevant to a specific feature.
+
+The output is a set of feature properties: concrete, testable claims about
+what the feature should do, what invariants it should maintain, and what
+behaviors should be reachable.
+
+## Step 1: Orient to the System
+
+Before you can analyze a feature, you need enough understanding of the system
+to navigate it. If full research artifacts exist in `antithesis/scratchbook/`
+(from the `antithesis-research` skill), read `sut-analysis.md` and use it as
+your orientation — skip this step.
+
+Otherwise, build a lightweight orientation scoped to the feature's
+neighborhood:
+
+1. **Architecture.** What are the major components? How do they communicate?
+   What are the entrypoints (`main()`, HTTP/gRPC handlers, CLI)? You need
+   enough to know which component the feature lives in and what talks to it.
+
+2. **Data flow.** Trace one representative request path from ingress through
+   business logic to persistence. Note where state changes happen, where
+   network calls cross service boundaries, and what consistency guarantees
+   exist (or are claimed).
+
+3. **Deployment topology.** How many processes, what roles, how are they
+   connected? This determines what your docker-compose needs to look like and
+   what fault scenarios are possible.
+
+4. **Concurrency model.** Threading, async patterns, event loops, locking
+   strategy. You need to know how concurrent operations interact before you
+   can assess whether the feature has timing-sensitive behavior.
+
+This is not a full SUT analysis. It is the minimum context to navigate the
+codebase for this specific feature. Spend enough time to orient, then move on.
+Record what you learn in the analysis file — it serves as context for the
+rest of the work.
+
+## Step 2: Understand the Feature
+
+### Entry points
+
+Feature-workload starts from one of two situations:
+
+**The feature is done.** Source code is available. Read the code, trace data
+flow through the feature, identify its state, concurrency characteristics, and
+failure modes. Understand the feature's API surface — what operations does it
+expose, what inputs does it accept, what outputs does it produce, what side
+effects does it have?
+
+Focus on:
+
+- Entry points into the feature — handlers, public methods, message consumers
+- Internal state the feature manages or modifies
+- Dependencies the feature relies on — databases, caches, external services,
+  other internal components
+- Error paths and how the feature handles failures from its dependencies
+- Concurrency — does the feature touch shared state? Can multiple callers
+  exercise it simultaneously? Are there locks, queues, or coordination
+  mechanisms?
+- Lifecycle — does the feature have setup, teardown, migration, or upgrade
+  paths?
+
+**The feature is in development.** Some code may exist, or there may only be
+a spec, design doc, or verbal description. Combine whatever code exists with
+the spec and conversation to build understanding. Identify what is built vs.
+what is planned.
+
+For the built parts, analyze them as above. For the planned parts:
+
+- What will the feature do? What operations, what data, what side effects?
+- What are the intended invariants? What should never happen?
+- What behaviors should be reachable? What states should the system visit?
+- What are the testability implications of the planned design? Are there
+  aspects that will be hard to observe or verify from outside?
+- What dependencies will the feature have? How will it interact with the
+  rest of the system?
+
+Properties for unbuilt parts become TDD-style stubs in the workload —
+assertions that will fail until the code catches up. Surfacing these
+properties early can influence the feature's design toward testability.
+
+## Step 3: Codebase Exploration
+
+Explore the codebase through lenses relevant to the feature. Not all lenses
+apply to every feature — use the ones the feature's characteristics point to.
+
+### Feature boundaries
+
+Where the feature interacts with the rest of the system. This lens is
+specific to feature-workload — it maps the surface area the workload needs
+to exercise and the contracts it needs to verify.
+
+- API contracts — what does the feature promise to its callers? Input
+  validation, output format, error semantics, idempotency guarantees.
+- Data flow in and out — what data enters the feature, where does it go,
+  what transformations happen, what state is written or read.
+- Shared state — does the feature read or write state that other features
+  also use? What coordination exists?
+- Event interfaces — does the feature emit or consume events, messages, or
+  notifications? What ordering or delivery guarantees exist?
+- Configuration — what config knobs affect the feature's behavior? What are
+  their defaults and limits?
+
+### Concurrency and timing
+
+Look for conditions where the feature's behavior depends on timing or
+interleaving:
+
+- Thread pools, event loops, async patterns on the feature's paths
+- Locks and their ordering — especially across the code paths involved
+- Shared mutable state touched by the feature's operations
+- Lock-free data structures with subtle ordering requirements
+- Concurrent access to collections or maps
+- Operations that assume sequential execution but can interleave
+
+Focus on "what if two callers exercise this feature at exactly the same
+moment":
+
+- Two writes to the same resource arriving concurrently
+- A read arriving while a write is in progress
+- A config change happening mid-operation
+- A health check passing right before a component the feature depends on
+  fails
+- The feature being exercised during startup or shutdown
+
+### State management
+
+Look for:
+
+- What state the feature manages — databases, caches, queues, in-memory
+  structures
+- How state moves between components — replication, propagation, caching
+- What happens to in-flight state during failures
+- Cache invalidation strategies and their edge cases
+- Persistence boundaries — where does durable meet volatile
+- State transitions — valid transitions, guarded transitions, transitions
+  that should be impossible
+
+### Failure and error handling
+
+Look for:
+
+- Error handling on the feature's code paths — missing checks, swallowed
+  errors, catch-all handlers
+- Retry logic — with or without backoff, with or without idempotency
+- Timeout handling and hardcoded timeout values
+- Partial failure paths — the messy states between "fully up" and "fully
+  down"
+- Recovery logic — what happens after a crash, restart, or reconnection
+- Degraded operation — does the feature have fallback behavior? Is it
+  correct?
+- Health check implementations — do they accurately reflect the feature's
+  ability to serve
+
+### Unproven assumptions
+
+Implicit axioms the feature is built on that are never validated. These are
+often the most productive targets for testing:
+
+- Error paths that don't exist ("this shouldn't happen")
+- Dependencies with no failure handling
+- Assumptions about clock synchronization
+- Assumptions about message ordering
+- Code that assumes a service is always reachable
+- Catch blocks that log and swallow without recovery
+- Assumptions about the order in which components start up
+
+### Bug history
+
+Check the feature's area for past bugs:
+
+- Related closed issues — the fix may not cover all edge cases
+- Recurring patterns in the same area — systemic issues
+- Recently changed code in the feature's paths — regressions
+- Known limitations or TODOs in the code
+
+A filed issue is a reported bug, not a confirmed one. Confirm the defect is
+real from primary evidence before building properties around it.
+
+## Step 4: Discover Feature Properties
+
+Turn what you learned into concrete, testable properties. Each property is a
+specific claim about the feature's behavior — an invariant, a reachable
+behavior, or a failure mode.
+
+Work through these focuses. Not all apply to every feature — use the ones
+relevant to what you found in the exploration above.
+
+### Data integrity
+
+- Does the feature guarantee that data written is data read back?
+- Are there consistency windows where stale reads are possible? If so, what
+  are the bounds?
+- Does the feature maintain referential integrity or ordering guarantees?
+- Can data be silently corrupted, truncated, or lost?
+
+Properties here are typically `Always` or `AlwaysOrUnreachable` — invariants
+that must hold on every evaluation.
+
+### Concurrency
+
+- What happens when multiple callers exercise the feature simultaneously?
+- Are there race conditions in the feature's state management?
+- Do concurrent operations produce results consistent with some serial
+  ordering?
+- Are there deadlock or livelock possibilities?
+
+Properties here may be `Always` (no data corruption under concurrent access)
+or `Sometimes` (concurrent operations can actually interleave — the workload
+reaches the concurrent state).
+
+### Failure recovery
+
+- Does the feature recover correctly after crashes, restarts, or network
+  failures?
+- Is in-flight state preserved or correctly discarded?
+- Does the feature converge to a correct state after transient failures?
+- Are there failure modes that leave the feature in a permanently broken
+  state?
+
+Properties here are often `Always` (no data loss after acknowledged write
+survives crash) with `Sometimes` reach claims proving the workload actually
+exercises crash-recovery paths.
+
+### Resource boundaries
+
+- Does the feature respect configured limits (queue sizes, connection pools,
+  batch sizes)?
+- What happens at capacity? Backpressure, rejection, degradation?
+- Are there off-by-one errors at boundary values?
+- Does the feature handle resource exhaustion gracefully?
+
+Properties here use `Always` for boundary respect and `Sometimes` for
+reaching capacity states.
+
+### Idempotency and replay
+
+- Are operations that claim to be idempotent actually idempotent?
+- What happens if the same request is sent twice?
+- Does retry behavior produce correct results?
+- Are there at-least-once or exactly-once guarantees, and do they hold?
+
+Properties here are typically `Always` — the idempotency guarantee must hold
+on every evaluation.
+
+### Protocol contracts
+
+- Does the feature implement a protocol correctly?
+- Are there message ordering requirements? Are they maintained?
+- Does the feature handle malformed input according to the protocol spec?
+- Are version negotiation or capability negotiation paths correct?
+
+Properties here are `Always` for protocol compliance.
+
+### Choosing the assertion type
+
+For each property, choose the Antithesis assertion type that matches its
+semantics:
+
+- **`Always`**: An invariant that must hold every time the check runs. Most
+  feature properties are this type.
+- **`AlwaysOrUnreachable`**: An invariant on an optional or rare path — if
+  the path executes, the invariant must hold, but "never executed" is
+  acceptable.
+- **`Sometimes(cond)`**: A reach claim — a state or condition that should
+  become true at least once. Use for proving the workload exercises the
+  feature's behaviors.
+- **`Reachable`**: A code path that should be reachable. Use for specific
+  outcomes or branch results.
+- **`Unreachable`**: A code path that should never be reached. Use for
+  forbidden paths.
+
+Record why you chose each assertion type — the rationale matters for review
+and iteration.
+
+## Attack Surfaces
+
+Common patterns where features tend to have problems — check whether any
+apply:
+
+- **State transitions under concurrent faults**: What happens if a dependency
+  fails mid-operation? Two callers modifying the same state simultaneously?
+- **Polling/caching with stale data**: Anything that observes state
+  asynchronously can act on outdated information.
+- **Race conditions between control and data paths**: Configuration changes
+  or topology updates arriving while the feature is actively serving.
+- **Recovery from partial failures**: Some dependencies down, not all.
+  Degraded state — does the feature behave correctly?
+- **Component interactions making things worse**: Retries overloading a
+  struggling dependency, cascading timeouts, thundering herd on recovery.
+- **Runtime configuration changes under load**: Config change while the
+  feature is actively serving traffic.
+- **Health reporting accuracy**: Feature says "healthy" but can't actually
+  serve.
+
+## Partial Failures
+
+Not just "dependency is up or down" but the messy states in between:
+
+- Process down but sidecar is up
+- Network partitioned to some peers but not others
+- Disk slow but not dead
+- CPU starved but not OOM-killed
+- Connection pool exhausted but process is "healthy"
+
+These partial failure modes often hide the most interesting bugs because
+features are designed for clean failure, not degraded operation.
+
+## Output
+
+Write findings to `antithesis/feature-workloads/<feature-slug>/analysis.md`:
+
+- Feature description — what the feature does, its API surface, its
+  dependencies
+- Development status — done or in development, what's built vs. planned
+- System orientation notes — enough architecture and data flow context for
+  someone reading the file to navigate the codebase
+- Relevant code paths — files, functions, line numbers
+- Discovered properties — each with a name, description, assertion type, and
+  rationale for the type choice. For in-development features, mark which
+  properties are for built vs. planned code
+- Fault assessment notes — which fault types matter for this feature and why
+  (see `references/faults.md`)
+- Open questions — what you couldn't resolve from the code or spec alone
+- What was examined and what was ruled out

--- a/antithesis-feature-workload/references/interesting-values.md
+++ b/antithesis-feature-workload/references/interesting-values.md
@@ -1,0 +1,114 @@
+# Interesting Values
+
+## Goal
+
+Choose values that exercise the feature's boundaries and edge cases. Don't
+draw from arbitrary ranges — use a menu of values that target the boundaries
+and configured limits relevant to the feature's properties.
+
+## Two Axes of Randomness
+
+Workload randomness has two axes:
+
+- The **menu axis** — what values are available to draw from. Covered here.
+- The **shape axis** — how often each value is drawn (probabilities, action
+  weights). Covered in `references/self-driving-workload.md` under "Randomness
+  and swarm testing."
+
+Both compose: the menu decides what values exist; the shape decides how often
+each is drawn. All draws must go through the SDK's random module for
+deterministic replay (see `references/assertions.md`).
+
+## Why the Menu Matters
+
+If random draws come from arbitrary ranges — `randint(0, 1000)` — most draws
+land in the bulk, far from any boundary. The corners where bugs hide get
+sampled rarely. A well-chosen menu targets the interesting values: boundaries
+of the input type plus values specific to the feature's code paths.
+
+What counts as interesting depends on the feature. The same value (a queue
+size of 100) matters intensely for a feature that manages backpressure and not
+at all for a feature that serializes messages. Find interesting values per
+feature property, at implementation time.
+
+## Boundary Values
+
+Every type has values where behavior changes — zero or empty, type minimums
+and maximums, off-by-one neighborhoods of those, type-specific edge cases (NaN
+for floats, encoding boundaries for strings, single-element collections). The
+feature's code paths narrow or expand this set:
+
+- A backpressure feature cares about empty and capacity
+- A pagination feature cares about zero, one, page size, and just-over
+- A parser feature cares about empty input and length-encoding boundaries
+- A timeout feature cares about zero, the timeout value, and just-over
+
+Include the boundaries that matter for the feature's inputs and types, then
+add the feature-specific values from discovery below.
+
+## Feature-Specific Discovery
+
+Build the value menu for the feature you're testing:
+
+1. **Start from the feature's properties.** What invariants did you identify?
+   What boundaries matter for each? These are the anchor.
+
+2. **Scan the SUT code paths the feature touches.** Look for configured limits
+   (queue capacities, batch sizes, replica counts, retry counts), default
+   values (timeouts, intervals, sizes), and threshold constants — the literal
+   values that decide what happens on those paths.
+
+3. **Cross-reference config files and env vars.** Values in code are often
+   parameterized; the runtime value depends on what the topology supplies.
+   Check both.
+
+4. **Check recent bug fixes in the touched paths.** Fixes for boundary or
+   off-by-one bugs often expose specific values worth including. If a quick
+   scan surfaces something, include it.
+
+## Structure: Families with Neighborhoods
+
+Interesting values come in families, not flat lists. A configured value `N`
+parameterizes a family: `{N-1, N, N+1, ...}`. The family is named by the
+config it parameterizes.
+
+When the parameterizing config is itself varied across runs (swarmed), the
+family rebuilds around whatever `N` is drawn for that run. The menu is a
+function of the parameters, not a static list.
+
+### Worked example: a timeout
+
+The feature uses a connection timeout of `CONNECT_TIMEOUT_MS = 5000`.
+
+- Boundaries: zero, one, max-of-i32
+- Family around N=5000: `{4999, 5000, 5001}` — just-under, at, just-over
+- Combined menu: `{0, 1, 4999, 5000, 5001, 30000, MAX_I32}`
+
+If `CONNECT_TIMEOUT_MS` is swarmed across `{100, 5000, 60000}`, the family
+rebuilds per run. A run with `CONNECT_TIMEOUT_MS = 100` uses
+`{0, 1, 99, 100, 101, 600, MAX_I32}`.
+
+### Worked example: a queue capacity
+
+The feature uses a bounded queue with capacity `QUEUE_CAPACITY = 64`.
+
+- Boundaries: zero, one, max-of-usize
+- Family around N=64: `{63, 64, 65}` — just-under, at, just-over
+- Combined menu: `{0, 1, 63, 64, 65, 128, MAX_USIZE}`
+
+If `QUEUE_CAPACITY` is swarmed across `{1, 64, 4096}`, the family rebuilds
+per run.
+
+## When the Menu Axis Doesn't Apply
+
+Some features don't have bounded inputs worth targeting — small fixed action
+vocabularies like `{create, drop}`, or pure reachability / fault-driven
+scenarios. For those, the menu axis is a no-op. Note this in the workload
+code:
+
+```
+# menu axis not applicable: action vocabulary is fixed at {create, drop}
+```
+
+Don't fabricate values to fill a gap. "We considered the menu axis and it
+doesn't apply" is a valid outcome.

--- a/antithesis-feature-workload/references/iteration.md
+++ b/antithesis-feature-workload/references/iteration.md
@@ -1,0 +1,196 @@
+# Iteration
+
+## Goal
+
+When feature properties aren't being exercised or reach claims aren't firing,
+decide what to change and change it. The iteration signal comes from what you
+observe: reach claims, workload output, triage results, and the feature's
+properties.
+
+## The Iteration Signal
+
+### Reach claims first
+
+Before adjusting anything, check reach claims:
+
+1. Are **operational reach claims** firing? (Is the workload performing
+   operations at all?)
+2. Are **behavior reach claims** firing? (Is the workload reaching the
+   feature's important states?)
+
+If operational reach claims aren't firing, the workload has a basic problem —
+it's not performing the operations it's supposed to. Fix this before anything
+else.
+
+If behavior reach claims aren't firing, the workload is running but not
+reaching the feature's key states. The workload needs to change — see
+"Workload adjustments" below.
+
+If reach claims are firing but invariants aren't being tested (assertions
+never evaluate), the workload is in the right neighborhood but the conditions
+for checking the property aren't aligning — see "Narrowing" below.
+
+Before treating an unfired reach claim as a gap, make sure it's a
+precondition claim, not the negation of an `Always` at the same site. The
+negation of a green `Always` cannot fire. Fix the claim, not the workload —
+see `references/assertions.md`, "A Reach Claim Asserts the Precondition,
+Never the Violation."
+
+### Triage results (Antithesis runs)
+
+After an Antithesis run, `antithesis-triage` reports property status:
+
+- **Passed**: The invariant held throughout. Good — but the workload may not
+  have reached all the conditions where the invariant could be violated.
+- **Failed**: The invariant was violated. This needs verification — see
+  `references/verification.md`.
+- **Unfound**: The assertion was never evaluated. The workload isn't reaching
+  the code path at all.
+
+Frame triage with a focused lens: "Are the feature's properties being
+exercised? Are the reach claims firing? Any failures?"
+
+## Iteration Moves
+
+There is no fixed order. Use what you observe to decide what to adjust.
+
+### Workload adjustments
+
+- **More concurrency.** If the feature involves shared state or concurrent
+  access, add more concurrent clients, threads, or operations.
+- **Different timing.** Add delays between operations, change batch sizes,
+  interleave different operation types.
+- **Different values.** Revisit the value menu — are you hitting the right
+  boundaries? Add values discovered from recent code reading. See
+  `references/interesting-values.md`.
+- **More aggressive patterns.** Operations that stress the feature harder —
+  rapid create/delete cycles, full/empty transitions, burst traffic.
+- **Operation ordering.** If a property involves a specific sequence of
+  operations, add workload modes that emphasize that sequence.
+- **Swarm parameters.** Vary the shape of randomness across runs — different
+  probability distributions, action weight biases. See
+  `references/self-driving-workload.md`, "Randomness and swarm testing."
+
+### Assertion adjustments
+
+- **Add intermediate assertions.** If you're unsure whether a property
+  violation is happening silently, add assertions that detect intermediate
+  states — states that should or shouldn't hold if the feature is working
+  correctly.
+- **Add SUT-side assertions.** When a property involves internal state the
+  workload can't observe directly, add surgical assertions in the SUT at
+  the relevant code points.
+- **Refine existing assertions.** An assertion that's too broad produces
+  false positives; too narrow misses real violations. Adjust based on what
+  you see.
+- **Add reach claims for deeper states.** If the current reach claims fire
+  but the workload isn't exercising interesting conditions, there may be
+  deeper states you haven't verified. Add claims further along the feature's
+  important paths.
+
+### SUT configuration adjustments
+
+- **Smaller buffers.** Reduce queue sizes, connection pool sizes, batch
+  sizes — operate closer to limits to make boundary conditions more likely.
+- **Shorter timeouts.** Make timeout-related properties exercise faster.
+- **Fewer replicas.** Reduce the number of replicas to concentrate state
+  transitions on fewer nodes.
+- **Enable fault types.** If a property involves crash recovery or clock
+  behavior, confirm the relevant faults are enabled (see
+  `references/faults.md`).
+
+### Property revision
+
+If nothing is working after 2–3 iterations, the properties may need revision.
+Go back to `references/feature-analysis.md`:
+
+- Re-examine the feature's code with what you've learned from running the
+  workload
+- Look for properties you missed — behaviors, invariants, or failure modes
+  that the workload is revealing
+- Consider whether existing properties are too broad or too narrow to test
+  effectively
+
+### Narrowing
+
+When reach claims fire but properties aren't being tested effectively:
+
+- The feature may need more specific workload patterns to create the exact
+  conditions for assertion evaluation
+- The assertions may be checking the wrong thing — the invariant is correct
+  but the check isn't positioned where the workload drives
+- The values may be wrong — the workload reaches the right operations but
+  with values that don't exercise the boundaries
+
+## Local vs Antithesis Iteration
+
+### Local iteration
+
+Faster feedback loops. Run the workload, observe, adjust, run again. Good for:
+
+- Verifying reach claims fire
+- Testing new operation patterns
+- Validating workload correctness (no assertion bugs)
+- Quick smoke tests (5-minute runs)
+
+### Antithesis iteration
+
+Slower but more powerful. Antithesis explores interleavings, injects faults,
+and searches the state space. Good for:
+
+- Properties that require fault injection
+- Properties that require specific scheduling
+- Exploring beyond what local concurrency can produce
+- Longer runs that cover more state space
+
+**Run duration guidance:**
+- Quick check: 10–15 minutes (verify harness works)
+- Standard run: 30–60 minutes (normal coverage)
+- Deep exploration: 2–4 hours (hard-to-exercise properties)
+
+Start short to verify the harness works, then increase duration as confidence
+grows that the workload is exercising the feature effectively.
+
+## Feature Evolution
+
+When the feature changes — new code lands, the spec evolves, requirements
+shift — the workload needs to keep up.
+
+### Detecting what changed
+
+- Re-read the feature's code or spec. What's new, modified, or removed?
+- Check which existing properties still hold against the current code
+- Identify new properties introduced by the changes
+- Identify properties that are now obsolete (the feature no longer has
+  the behavior they test)
+
+### Updating the workload
+
+- **New properties**: Add assertions and reach claims. For properties on
+  unbuilt code, add TDD-style stubs that will fail until the code lands.
+- **Changed properties**: Update assertions to match the new behavior. A
+  property that was "counter never decreases" might become "counter never
+  decreases by more than the rebalance threshold."
+- **Obsolete properties**: Remove assertions and reach claims that test
+  behavior the feature no longer has. Don't leave dead assertions — they
+  produce false positives or never fire.
+- **New operations**: Add workload operations to exercise new API surface.
+  Update value menus for new code paths.
+
+### Re-validating
+
+After updating, re-validate locally. The same iteration loop applies: check
+reach claims, verify assertions, iterate.
+
+## Recording Iterations
+
+After each iteration, update
+`antithesis/feature-workloads/<feature-slug>/analysis.md`:
+
+- What was changed and why
+- What was observed (reach claims, assertion results, workload behavior)
+- Whether properties were revised
+- What to try next
+
+This trail is critical — without it, the next iteration starts from scratch
+instead of building on what's been learned.

--- a/antithesis-feature-workload/references/self-driving-workload.md
+++ b/antithesis-feature-workload/references/self-driving-workload.md
@@ -1,0 +1,253 @@
+# Self-Driving Workload
+
+## Goal
+
+Build a workload that exercises a feature's behaviors, checks its properties,
+and runs identically locally and in Antithesis. The workload does not use Test
+Composer — it is a single program that manages its own lifecycle.
+
+## Why Not Test Composer
+
+Test Composer orchestrates multiple commands with different scheduling
+semantics (parallel drivers, serial drivers, eventually checks). That
+orchestration layer only runs inside Antithesis. A self-driving workload runs
+the same code locally and in Antithesis — the only difference is whether SDK
+assertions emit to a file or no-op. This means:
+
+- You can iterate locally with fast feedback loops before paying for
+  Antithesis runs
+- The workload behavior is identical in both environments — no "works locally
+  but not in Antithesis" bugs in the harness itself
+- You control the exact scenario: operation sequence, timing, validation
+  points
+
+The tradeoff is that you manage your own lifecycle. Test Composer handles
+parallelism, serialization, phasing, and quiet periods automatically. A
+self-driving workload implements whatever subset of that it needs.
+
+## Structure
+
+### Single entrypoint
+
+The workload is one program with one entrypoint. It starts, drives operations
+against the SUT, checks results, and eventually exits (or runs continuously
+for local use). The entrypoint handles both local and Antithesis modes.
+
+### Dual-mode assertions
+
+When `ANTITHESIS_OUTPUT_DIR` is set, the workload is running inside
+Antithesis. Use SDK assertions: `Always`, `Sometimes`, `Reachable`,
+`AlwaysOrUnreachable`, `Unreachable`. These emit structured data that
+Antithesis uses for property checking, branch guidance, and replay.
+
+When `ANTITHESIS_OUTPUT_DIR` is not set, the workload is running locally. Use
+equivalent local checks: log violations, exit non-zero on critical failures,
+print diagnostic output. The simplest pattern:
+
+```python
+import os
+ANTITHESIS = bool(os.environ.get("ANTITHESIS_OUTPUT_DIR"))
+
+if ANTITHESIS:
+    from antithesis.assertions import always
+    always(condition, "property name", details)
+else:
+    if not condition:
+        print(f"VIOLATION: property name — {details}")
+        sys.exit(1)
+```
+
+Wrap this in a helper so assertion callsites are clean. The helper still uses
+inline constant string literals for the property name — the name is passed
+through the helper, but it originates as a literal at the callsite. See
+`references/assertions.md` for naming requirements.
+
+### Main loop
+
+The workload typically runs in a loop:
+
+1. Perform operations against the SUT (writes, reads, transactions, API calls)
+2. Check invariants after each operation or batch of operations
+3. Track what was attempted and what was acknowledged
+4. Repeat
+
+For local use, the loop can run continuously (`while True`) or for a bounded
+number of operations / duration. For Antithesis, continuous is fine — Antithesis
+controls the timeline's lifetime.
+
+A common pattern is two modes controlled by an environment variable:
+
+- **Continual**: Run forever, checking invariants periodically. Good for local
+  development and for Antithesis runs.
+- **Epochal**: Run a fixed number of operations, then do a final consistency
+  check and exit. Good for CI smoke tests.
+
+### Operation design
+
+Design operations to exercise the feature's behaviors and drive the system
+toward states where properties are stressed.
+
+**Exercise the full API surface.** Cover the feature's operations — creates,
+reads, updates, deletes, whatever the feature exposes. Include adjacent
+operations that interact with the feature. Configuration, administration, and
+setup functions tend to hide bugs and are easy to overlook.
+
+**Drive toward interesting states.** Don't just call the API — drive the
+system toward states where the feature's properties are tested. Full queues,
+empty caches, concurrent updates, boundary values, transitions between
+states. Each discovered property suggests operations that would stress it.
+
+**Don't avoid expected failures.** Operations that encounter errors, timeouts,
+and partial failures are valuable — they test the feature's error handling and
+recovery. Recovery processes hide a disproportionate number of bugs.
+
+**Exercise concurrency.** If the feature involves shared state or concurrent
+access, drive multiple concurrent clients or threads. The degree of
+concurrency is a tunable parameter — too much swamps the system, too little
+misses the interleaving.
+
+**Cover both normal and edge cases.** The feature's happy path matters, but
+bugs hide in the edges — boundary values, empty inputs, maximum sizes, rapid
+transitions between states.
+
+### Continuous validation
+
+Validate as you go, not just at the end. Check invariants after each operation
+or small batch, not after a thousand operations. Three reasons:
+
+1. **Bugs cancel each other out.** The system enters a broken state, then by
+   luck recovers before a final check would notice.
+2. **Debugging is harder with distance.** A long history between cause and
+   detection makes investigation harder.
+3. **Earlier detection is cheaper.** Finding the bug in the first minute beats
+   finding it after an hour of irrelevant history.
+
+### Randomness and swarm testing
+
+All randomness in the workload must go through the Antithesis SDK's random
+module for deterministic replay. This applies to operation selection, value
+generation, timing decisions, and any other random choices. When running
+locally (no SDK), use the standard library's random module.
+
+**Vary the shape of randomness across runs.** Don't hardcode probabilities
+and action weights as constants. At the start of each run (or each Antithesis
+timeline), draw those parameters from a wide range — including the extremes
+— so some runs are heavily biased toward one class of operation and others
+are biased the other way.
+
+This is swarm testing: a single run that's deliberately skewed goes deep into
+one corner of the feature's state space; across many runs, the union of skews
+covers the surface and finds bugs that uniform mixing never reaches.
+
+A simple implementation: for each tunable probability, replace `P = 0.3` with
+`P = random_choice([0.02, 0.3, 0.95])` from the SDK's random module. Three
+buckets is illustrative — what matters is covering the extremes plus a middle
+case. For action weights, occasionally zero out one or more entries to explore
+what happens when an operation class is absent.
+
+Also include **action omission**: drop each class of action independently with
+some small probability at the start of the run. Re-roll if the result is
+empty. The limiting case of skew — an entire operation class absent — can
+surface bugs that always-present action mixes never find.
+
+### Value selection
+
+Don't draw values from arbitrary ranges. Use value menus: boundary values
+for the input type plus configured-limit families from the feature's code
+paths. See `references/interesting-values.md` for how to build the menu.
+
+### Quiet periods for liveness checks
+
+When running in Antithesis, the workload can request a quiet period — all
+fault injection stops temporarily, giving the system time to recover. This
+is useful for checking liveness properties: does the system converge to a
+correct state after faults stop?
+
+The mechanism: Antithesis injects an `ANTITHESIS_STOP_FAULTS` binary into
+every container and sets the corresponding environment variable.
+
+```bash
+[ "${ANTITHESIS_STOP_FAULTS}" ] && "${ANTITHESIS_STOP_FAULTS}" <DURATION_SECONDS>
+```
+
+The guard clause lets the script run harmlessly outside Antithesis. After the
+quiet period, faults resume automatically.
+
+Use this for mid-run liveness checks: drive operations under faults, request
+a quiet period, wait for the system to stabilize, check whether it recovered
+correctly, then resume. This is valuable for features that involve recovery,
+replication, or convergence.
+
+## Fault Tolerance
+
+The workload runs under fault injection in Antithesis. Transient errors are
+expected, not exceptional. The workload's job is to keep making progress, not
+bail on the first failure.
+
+### Design for goals, not procedures
+
+Write workload operations as loops that drive toward an objective, not fixed
+sequences of attempts. A workload that tracks "I tried 100 times" has nothing
+useful to assert against in a faulty environment; one that tracks progress
+against a goal can assert on that progress.
+
+### Construct bounds, don't claim exact knowledge
+
+Under fault injection the workload doesn't have perfect visibility — requests
+fail in flight, acknowledgments get dropped, clocks drift. Record enough of
+what happened to construct bounds the SUT must satisfy.
+
+The most common way: track attempts and acknowledgments separately. If the
+workload sends 100 increment requests and 80 are acknowledged, the counter
+must have changed by some number between 80 and 100 — unacknowledged requests
+may have succeeded anyway. A later read showing 75 or 120 is a bug. A
+workload that records only "I called increment 100 times" has no bound to
+assert against.
+
+See `references/assertions.md`, "Assert Bounds, Not Exact Values" for how to
+express bounds as assertions.
+
+### Retries are inputs to the system
+
+Retries shape what bugs you find. Retrying after a lost acknowledgment can
+surface real idempotency bugs (good — that's a production scenario). Retrying
+past the SUT's idempotency contract creates faulty client behavior that
+produces false-positive assertion failures (bad). Decide what the SUT promises
+about idempotency before designing retry behavior.
+
+### Faults to handle
+
+See `references/faults.md` for the full catalog. At minimum, handle:
+
+- Process kill/restart (connections drop, state may be lost)
+- Network partition (requests fail, some unidirectionally)
+- Clock skew (timestamps may go backward)
+- I/O delays/stalls (operations take unexpectedly long)
+
+### Common fault tolerance patterns
+
+- **Retry with backoff.** Exponential or jittered backoff for transient
+  failures. Don't retry indefinitely for non-transient errors.
+- **Reconnect on disconnect.** Connections will drop. The workload should
+  reconnect and resume, not crash.
+- **Timeout operations.** Don't wait forever. Set timeouts and treat them as
+  transient failures.
+- **Track state across retries.** If a retried operation might have succeeded
+  on the first attempt (lost acknowledgment), track both possibilities in your
+  bounds.
+
+## Production Isolation
+
+- Code in the `antithesis/` directory should never make it to production.
+- Edits outside that directory should be surgical and walled off.
+- Antithesis-only code does not need heavy configuration — prefer simple,
+  explicit logic.
+- SDK assertions no-op outside Antithesis, so SUT-side assertions are safe in
+  production — they become low-overhead fallbacks.
+
+## Output
+
+- Workload program under `antithesis/` (or wherever the project keeps
+  test/workload code)
+- Docker-compose service definition for the workload container
+- Helper utilities as needed (client wrappers, mock services)

--- a/antithesis-feature-workload/references/verification.md
+++ b/antithesis-feature-workload/references/verification.md
@@ -1,0 +1,136 @@
+# Verification
+
+## Goal
+
+When a property fails, determine whether the failure represents a real bug
+in the SUT or a problem in the harness. A property failure is a candidate,
+not a conclusion.
+
+## Reading the Counterexample
+
+Whether from local output or Antithesis triage:
+
+1. **Identify the sequence of events** leading to the failure. What operations
+   happened? What state was the system in? What faults were active?
+2. **Identify the assertion that failed.** Which specific assertion? What were
+   the values at the moment of failure?
+3. **Compare to the feature's properties.** Does the observed sequence
+   represent a genuine violation of the property? Is the invariant actually
+   broken, or did the assertion check the wrong thing?
+
+For Antithesis runs, use `antithesis-triage` to get the failure details. If
+the triage output isn't enough to understand the mechanism, use
+`antithesis-debug` to inspect container state at the failure moment — the
+Multiverse Debugger lets you time-travel through the sequence and inspect
+state at any point.
+
+## Classifying the Finding
+
+### Real bug in SUT
+
+The assertion correctly detected a violation of a feature property. Evidence:
+
+- The sequence of events demonstrates the bug's mechanism — you can explain
+  step by step how the system arrived at the incorrect state
+- The failure is reproducible (locally, in Antithesis, or both)
+- No harness, assertion, or workload bug explains the observation
+
+Any real bug found while testing a feature is valuable. Record it and decide
+with the user whether to fix it now or continue testing other properties.
+
+### Assertion bug
+
+The assertion itself is wrong or too strict. Evidence:
+
+- The SUT behavior is actually correct given the inputs and conditions
+- The assertion doesn't account for a valid edge case, a transient state,
+  or a legitimate execution order
+- The assertion fails on correct behavior, not on a bug
+
+Common assertion bugs:
+
+- **Too strict on timing.** The assertion checks a condition that's transiently
+  false during normal operation (e.g., checking consistency during an in-flight
+  update).
+- **Wrong bound.** The assertion uses exact equality instead of bounded
+  assertions. Under fault injection, unacknowledged operations may have
+  succeeded.
+- **Missing precondition.** The assertion checks a condition that only makes
+  sense after specific setup, but the workload sometimes evaluates it before
+  setup completes.
+- **Stale state.** The assertion reads state that hasn't propagated yet and
+  treats the stale value as incorrect.
+
+Fix the assertion and continue testing.
+
+### Workload bug
+
+The workload created an invalid scenario. Evidence:
+
+- The workload sent malformed input, violated a protocol, or misused an API
+- The SUT's response to the invalid input is correct (or at least not a
+  property violation)
+- The assertion failure is a consequence of the workload's mistake, not a
+  SUT defect
+
+Common workload bugs:
+
+- **Violating idempotency contracts.** Retrying an operation the SUT doesn't
+  promise is idempotent, then asserting on the unexpected result.
+- **Race in the workload.** The workload's own concurrency creates an invalid
+  state in its tracking data, causing a false assertion.
+- **Wrong operation sequence.** The workload calls APIs in an order the SUT
+  doesn't support and treats the error as a bug.
+- **Incorrect bounds tracking.** The workload miscounts attempts or
+  acknowledgments, producing wrong bounds that the SUT correctly violates.
+
+Fix the workload and continue testing.
+
+### Environment issue
+
+Infrastructure or configuration problem. Evidence:
+
+- The failure is caused by a misconfigured container, missing dependency,
+  incorrect network setup, or resource exhaustion in the test environment
+- The SUT never entered the state the assertion checks because the
+  environment prevented it from running normally
+
+Common environment issues:
+
+- **Containers can't reach each other.** Network misconfiguration, DNS
+  resolution failure, wrong IP addresses.
+- **Container crash loops.** OOM, missing config files, broken entrypoints.
+- **Missing SDK setup.** `ANTITHESIS_OUTPUT_DIR` not set, SDK not initialized,
+  assertion catalog not linked.
+- **Resource exhaustion.** Disk full, port conflicts, connection limits.
+
+Fix the environment and continue testing.
+
+## Verification Questions
+
+For any finding, ask:
+
+1. **Can I explain the mechanism step by step?** If not, dig deeper — use
+   `antithesis-debug` for Antithesis runs, add logging for local runs.
+2. **Is the SUT actually wrong?** The sequence shows what happened; that's
+   not the same as wrong. The SUT may have correctly handled an unusual but
+   valid scenario.
+3. **Could the workload have caused this?** Check whether the workload's
+   own behavior (retries, concurrent access, operation ordering) created the
+   conditions rather than the SUT's logic.
+
+## Documenting Findings
+
+When a finding is verified, record it in
+`antithesis/feature-workloads/<feature-slug>/analysis.md`:
+
+- **Sequence**: The step-by-step sequence of events that led to the finding —
+  what operations, what state, what timing or faults.
+- **Detection**: Which assertion detected it and what the values were at
+  failure.
+- **Mechanism**: How the system arrives at the incorrect state — the root
+  cause, not just the symptoms.
+- **Counterexample details**: For Antithesis runs: run ID, moment, containers
+  involved. For local runs: log output, timestamps.
+- **Classification**: Real SUT bug, assertion bug, workload bug, or
+  environment issue — and the evidence for the classification.


### PR DESCRIPTION
Parallel entry point into the Antithesis workflow for testing a specific feature. Where the standard pipeline does broad research → setup → workload, this skill goes feature analysis → targeted workload → iterate.

Self-driving workload (no Test Composer), dual-mode assertions, runs identically locally and in Antithesis. Handles features that are done or still in development — in-development features get TDD-style assertion stubs that go green as code lands.

Same structural pattern as `antithesis-bug-hunt`: self-contained skill with its own reference files, delegates to `antithesis-setup`/`antithesis-launch`/`antithesis-triage`/`antithesis-debug` for infrastructure and analysis. Iterative with loops, not a pipeline.

Files:
- `antithesis-feature-workload/SKILL.md` — main skill with three workflows (build, iterate, update for feature changes)
- 7 reference files adapted from the bug-hunt skill, reframed for feature testing
- README updated (overview, starter prompts, permissions table, installer list)

`make validate` passes.

Observation for the bug-hunt branch: its `iteration.md` references a "Narrowing" subsection that doesn't exist. The feature-workload version adds it — worth backporting.
